### PR TITLE
Change chain ID type to number for HardhatConfigNetwork

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ export function hardhatEtherscan(): HardhatEtherscanNetworks {
 
     etherscan.customChains.push({
       network: chain.alias,
-      chainId: chain.id,
+      chainId: parseInt(chain.id),
       urls: {
         apiURL: explorer.api!.url,
         browserURL: explorer.browserUrl,

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export function hardhatConfigNetworks(): HardhatConfigNetworks {
   return CHAINS.reduce((networks, chain) => {
     networks[chain.alias] = {
       accounts: { mnemonic: '' },
-      chainId: chain.id,
+      chainId: parseInt(chain.id),
       url: chain.providerUrl,
     };
     return networks;

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ export function hardhatEtherscan(): HardhatEtherscanNetworks {
 
     etherscan.customChains.push({
       network: chain.alias,
-      chainId: parseInt(chain.id),
+      chainId: Number(chain.id),
       urls: {
         apiURL: explorer.api!.url,
         browserURL: explorer.browserUrl,

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export function hardhatConfigNetworks(): HardhatConfigNetworks {
   return CHAINS.reduce((networks, chain) => {
     networks[chain.alias] = {
       accounts: { mnemonic: '' },
-      chainId: parseInt(chain.id),
+      chainId: Number(chain.id),
       url: chain.providerUrl,
     };
     return networks;

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,7 @@ export type ChainExplorerAPIKey = z.infer<typeof chainExplorerAPIKeySchema>;
 export interface HardhatConfigNetworks {
   [key: string]: {
     accounts: { mnemonic: '' };
-    chainId: string;
+    chainId: number;
     url: string;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,7 @@ export interface HardhatEtherscanNetworks {
   apiKey: { [etherscanAlias: string]: string; }
   customChains: {
     network: string;
-    chainId: string;
+    chainId: number;
     urls: { apiURL: string; browserURL: string; }
   }[]
 }


### PR DESCRIPTION
See https://github.com/NomicFoundation/hardhat/blob/231f7c47637821970dffa3d496c370afd7858bf2/packages/hardhat-core/src/types/config.ts#L183

`hardhatConfigNetworks()` output currently can't be used in hardhat directly, I need to typecast the chain IDs (otherwise 2.0.0 seems 100% backwards compatible)