### PR TITLE
Update Hardhat config to remove the need for boilerplate code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@
   - [hardhat-etherscan](#hardhat-etherscan)
 - [API](#api)
   - [CHAINS](#chains)
-  - [hardhatConfigNetworks](#hardhatconfignetworks)
-  - [hardhatEtherscan](#hardhatetherscan)
-  - [getEnvVariables](#getenvvariables)
+  - [hardhatConfig.networks()](#hardhatconfignetworks)
+  - [hardhatConfig.etherscan()](#hardhatconfigetherscan)
+  - [hardhatConfig.getEnvVariableNames()](#hardhatconfiggetenvvariablenames)
   - [Types](#types)
 - [Scripts](#scripts)
   - [generate:chains](#generatechains)
+  - [providers:ping](#providersping)
 - [Development](#development)
   - [Validation](#validation)
 - [Building](#building)
@@ -53,7 +54,7 @@ A static array of `Chain` objects.
 ```ts
 import { CHAINS } from '@api3/chains';
 console.log(CHAINS);
-/* 
+/*
 [
   {
     name: 'Arbitrum testnet',
@@ -62,17 +63,17 @@ console.log(CHAINS);
     ...
   },
   ...
-]   
+]
 */
 ```
 
-### hardhatConfigNetworks
+### hardhatConfig.networks()
 
 Returns an object where the key is each chain's alias and the value is an object that can be used as the `networks` field of [`hardhat.config.js`](https://hardhat.org/hardhat-runner/docs/config).
 
 ```ts
-import { hardhatConfigNetworks } from '@api3/chains';
-console.log(hardhatConfigNetworks());
+import { hardhatConfig } from '@api3/chains';
+console.log(hardhatConfig.networks());
 /*
 {
   "arbitrum-goerli-testnet": {
@@ -85,13 +86,13 @@ console.log(hardhatConfigNetworks());
 */
 ```
 
-### hardhatEtherscan
+### hardhatConfig.etherscan()
 
 Returns an object where the key is each chain's alias and the value is an object that can be used as the `etherscan` field of [`hardhat.config.js`](https://hardhat.org/hardhat-runner/docs/config) (requires the [`hardhat-etherscan` plugin](https://hardhat.org/hardhat-runner/plugins/nomiclabs-hardhat-etherscan)).
 
 ```ts
-import { hardhatEtherscan } from '@api3/chains';
-console.log(hardhatEtherscan());
+import { hardhatConfig } from '@api3/chains';
+console.log(hardhatConfig.etherscan());
 /*
 {
   apiKey: {
@@ -104,17 +105,19 @@ console.log(hardhatEtherscan());
 */
 ```
 
-### getEnvVariables
+### hardhatConfig.getEnvVariableNames()
 
 Returns an array of expected environment variable names for chains that have an API key required for the explorer.
 
+NOTE: Each `ETHERSCAN_API_KEY_` environment variable has the chain alias as a suffix, where the alias has been converted to upper snake case.
+
 ```ts
-import { getEnvVariables } from '@api3/chains';
-console.log(getEnvVariables());
+import { hardhatConfig } from '@api3/chains';
+console.log(hardhatConfig.getEnvVariableNames());
 /*
 [
   'MNEMONIC',
-  'ETHERSCAN_API_KEY_arbitrum-goerli-testnet',
+  'ETHERSCAN_API_KEY_ARBITRUM_GOERLI_TESTNET',
   ...
 ]
 */

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ console.log(hardhatConfig.etherscan());
 
 ### hardhatConfig.getEnvVariableNames()
 
-Returns an array of expected environment variable names for chains that have an API key required for the explorer.
+Returns an array of expected environment variable names for chains that have an API key required for the explorer. The array also includes a single `MNEMONIC` variable that can be used to configure all networks.
 
 NOTE: Each `ETHERSCAN_API_KEY_` environment variable has the chain alias as a suffix, where the alias has been converted to upper snake case.
 

--- a/src/hardhat-config.ts
+++ b/src/hardhat-config.ts
@@ -45,7 +45,7 @@ export function etherscan(): HardhatEtherscanConfig {
         },
       });
 
-      etherscan.apiKey[chain.alias] = apiKeyValue || '';
+      etherscan.apiKey[chain.alias] = apiKeyValue;
 
       return etherscan;
     },

--- a/src/hardhat-config.ts
+++ b/src/hardhat-config.ts
@@ -4,18 +4,18 @@ import { Chain, HardhatEtherscanConfig, HardhatNetworksConfig } from './types';
 
 export function getEnvVariableNames(): string[] {
   const hardhatApiKeyEnvNames = CHAINS.filter((chain) => chain.explorer?.api?.key?.required).map((chain) =>
-    buildEtherscanApiKeyName(chain)
+    etherscanApiKeyName(chain)
   );
 
   return ['MNEMONIC', ...hardhatApiKeyEnvNames];
 }
 
-export function buildEtherscanApiKeyName(chain: Chain): string {
+export function etherscanApiKeyName(chain: Chain): string {
   return `ETHERSCAN_API_KEY_${toUpperSnakeCase(chain.alias)}`;
 }
 
 // https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify#multiple-api-keys-and-alternative-block-explorers
-export function buildEtherscanConfig(): HardhatEtherscanConfig {
+export function etherscan(): HardhatEtherscanConfig {
   if (typeof window !== 'undefined') {
     throw new Error('Cannot be run outside of a Node.js environment');
   }
@@ -28,7 +28,7 @@ export function buildEtherscanConfig(): HardhatEtherscanConfig {
 
       const apiKey = chain.explorer.api.key;
 
-      const apiKeyEnvName = buildEtherscanApiKeyName(chain);
+      const apiKeyEnvName = etherscanApiKeyName(chain);
       const apiKeyValue = apiKey.required ? process.env[apiKeyEnvName] || 'NOT_FOUND' : 'DUMMY_VALUE';
 
       if (apiKey.hardhatEtherscanAlias) {
@@ -53,7 +53,7 @@ export function buildEtherscanConfig(): HardhatEtherscanConfig {
   );
 }
 
-export function buildNetworksConfig(): HardhatNetworksConfig {
+export function networks(): HardhatNetworksConfig {
   if (typeof window !== 'undefined') {
     throw new Error('Cannot be called outside of a Node.js environment');
   }

--- a/src/hardhat.ts
+++ b/src/hardhat.ts
@@ -51,6 +51,11 @@ export function buildEtherscanConfig(): HardhatEtherscanConfig {
 }
 
 export function buildNetworksConfig(): HardhatNetworksConfig {
+  // Not usable outside of a Node.js environment
+  if (typeof window !== 'undefined') {
+    return {};
+  }
+
   return CHAINS.reduce((networks, chain) => {
     networks[chain.alias] = {
       accounts: { mnemonic: process.env.MNEMONIC || '' },

--- a/src/hardhat.ts
+++ b/src/hardhat.ts
@@ -1,0 +1,53 @@
+import { CHAINS } from './generated/chains';
+import { toUpperSnakeCase } from './utils/strings';
+import { HardhatEtherscanConfig, HardhatNetworksConfig } from './types';
+
+// https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify#multiple-api-keys-and-alternative-block-explorers
+export function buildEtherscanConfig(): HardhatEtherscanConfig {
+  // Not usable outside of a Node.js environment
+  if (typeof window !== 'undefined') {
+    return { apiKey: {}, customChains: [] };
+  }
+
+  return CHAINS.reduce((etherscan, chain) => {
+    if (!chain.explorer || !chain.explorer.api) {
+      return etherscan;
+    }
+
+    const explorer = chain.explorer;
+    const apiKey = chain.explorer.api.key;
+
+    const apiKeyEnvName = `${toUpperSnakeCase(chain.alias)}_ETHERSCAN_API_KEY`;
+    const apiKeyValue = apiKey.required ? chain.alias : process.env[apiKeyEnvName];
+
+    if (apiKey.hardhatEtherscanAlias) {
+      etherscan.apiKey[apiKey.hardhatEtherscanAlias] = apiKeyValue || '';
+      return etherscan;
+    }
+
+    etherscan.customChains.push({
+      network: chain.alias,
+      chainId: Number(chain.id),
+      urls: {
+        apiURL: explorer.api?.url || '',
+        browserURL: explorer.browserUrl,
+      },
+    });
+
+    etherscan.apiKey[chain.alias] = apiKeyValue || '';
+
+    return etherscan;
+  }, { apiKey: {}, customChains: [] } as HardhatEtherscanConfig);
+}
+
+export function buildNetworksConfig(): HardhatNetworksConfig {
+  return CHAINS.reduce((networks, chain) => {
+    networks[chain.alias] = {
+      accounts: { mnemonic: '' },
+      chainId: Number(chain.id),
+      url: chain.providerUrl,
+    };
+    return networks;
+  }, {} as HardhatNetworksConfig);
+}
+

--- a/src/hardhat.ts
+++ b/src/hardhat.ts
@@ -53,7 +53,7 @@ export function buildEtherscanConfig(): HardhatEtherscanConfig {
 export function buildNetworksConfig(): HardhatNetworksConfig {
   return CHAINS.reduce((networks, chain) => {
     networks[chain.alias] = {
-      accounts: { mnemonic: '' },
+      accounts: { mnemonic: process.env.MNEMONIC || '' },
       chainId: Number(chain.id),
       url: chain.providerUrl,
     };

--- a/src/hardhat.ts
+++ b/src/hardhat.ts
@@ -1,6 +1,16 @@
 import { CHAINS } from './generated/chains';
 import { toUpperSnakeCase } from './utils/strings';
-import { HardhatEtherscanConfig, HardhatNetworksConfig } from './types';
+import { Chain, HardhatEtherscanConfig, HardhatNetworksConfig } from './types';
+
+export function buildEnvVariables(): string[] {
+  return CHAINS
+    .filter((chain) => chain.explorer?.api?.key?.required)
+    .map((chain) => buildEtherscanApiKeyName(chain));
+}
+
+export function buildEtherscanApiKeyName(chain: Chain): string {
+  return `${toUpperSnakeCase(chain.alias)}_ETHERSCAN_API_KEY`;
+}
 
 // https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify#multiple-api-keys-and-alternative-block-explorers
 export function buildEtherscanConfig(): HardhatEtherscanConfig {
@@ -17,7 +27,7 @@ export function buildEtherscanConfig(): HardhatEtherscanConfig {
     const explorer = chain.explorer;
     const apiKey = chain.explorer.api.key;
 
-    const apiKeyEnvName = `${toUpperSnakeCase(chain.alias)}_ETHERSCAN_API_KEY`;
+    const apiKeyEnvName = buildEtherscanApiKeyName(chain);
     const apiKeyValue = apiKey.required ? chain.alias : process.env[apiKeyEnvName];
 
     if (apiKey.hardhatEtherscanAlias) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,14 @@
-import { CHAINS } from './generated/chains';
-import { buildEtherscanConfig, buildNetworksConfig } from './hardhat';
-import { toUpperSnakeCase } from './utils/strings';
-
-export * from './types';
+import * as hardhat from './hardhat';
 
 // NOTE: the following file is generated with the generate-chains.ts script
 export { CHAINS } from './generated/chains';
 
-export const hardhat = { buildEtherscanConfig, buildNetworksConfig };
+export * as hardhat from './hardhat';
+export * from './types';
 
 export function getEnvVariables(): string[] {
-  const keys = CHAINS
-    .filter((chain) => chain.explorer?.api?.key?.required)
-    .map((chain) => `${toUpperSnakeCase(chain.alias)}_ETHERSCAN_API_KEY`);
+  const hardhatEnvVariables = hardhat.buildEnvVariables();
 
-  return ['MNEMONIC', ...keys];
+  return ['MNEMONIC', ...hardhatEnvVariables];
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,55 +1,18 @@
 import { CHAINS } from './generated/chains';
-import { HardhatConfigNetworks, HardhatEtherscanNetworks } from './types';
+import { buildEtherscanConfig, buildNetworksConfig } from './hardhat';
+import { toUpperSnakeCase } from './utils/strings';
 
 export * from './types';
 
 // NOTE: the following file is generated with the generate-chains.ts script
 export { CHAINS } from './generated/chains';
 
-export function hardhatConfigNetworks(): HardhatConfigNetworks {
-  return CHAINS.reduce((networks, chain) => {
-    networks[chain.alias] = {
-      accounts: { mnemonic: '' },
-      chainId: Number(chain.id),
-      url: chain.providerUrl,
-    };
-    return networks;
-  }, {} as HardhatConfigNetworks);
-}
-
-export function hardhatEtherscan(): HardhatEtherscanNetworks {
-  return CHAINS.reduce((etherscan, chain) => {
-    if (!chain.explorer || !chain.explorer.api) {
-      return etherscan;
-    }
-
-    const apiKey = chain.explorer.api.key;
-    const explorer = chain.explorer;
-    const apiKeyValue = apiKey.required ? chain.alias : "DUMMY_VALUE";
-
-    if (apiKey.hardhatEtherscanAlias) {
-      etherscan.apiKey[apiKey.hardhatEtherscanAlias] = apiKeyValue;
-      return etherscan;
-    }
-
-    etherscan.customChains.push({
-      network: chain.alias,
-      chainId: Number(chain.id),
-      urls: {
-        apiURL: explorer.api!.url,
-        browserURL: explorer.browserUrl,
-      },
-    });
-    etherscan.apiKey[chain.alias] = apiKeyValue;
-
-    return etherscan;
-  }, { apiKey: {}, customChains: [] } as HardhatEtherscanNetworks);
-}
+export const hardhat = { buildEtherscanConfig, buildNetworksConfig };
 
 export function getEnvVariables(): string[] {
   const keys = CHAINS
     .filter((chain) => chain.explorer?.api?.key?.required)
-    .map((chain) => `ETHERSCAN_API_KEY_${chain.alias}`);
+    .map((chain) => `${toUpperSnakeCase(chain.alias)}_ETHERSCAN_API_KEY`);
 
   return ['MNEMONIC', ...keys];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,5 @@
-import * as hardhat from './hardhat';
-
 // NOTE: the following file is generated with the generate-chains.ts script
 export { CHAINS } from './generated/chains';
 
 export * as hardhat from './hardhat';
 export * from './types';
-
-export function getEnvVariables(): string[] {
-  const hardhatEnvVariables = hardhat.buildEnvVariables();
-
-  return ['MNEMONIC', ...hardhatEnvVariables];
-}
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // NOTE: the following file is generated with the generate-chains.ts script
 export { CHAINS } from './generated/chains';
 
-export * as hardhat from './hardhat';
+export * as hardhatConfig from './hardhat-config';
 export * from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,7 @@ export type ChainExplorer = z.infer<typeof chainExplorerSchema>;
 export type ChainExplorerAPI = z.infer<typeof chainExplorerAPISchema>;
 export type ChainExplorerAPIKey = z.infer<typeof chainExplorerAPIKeySchema>;
 
-export interface HardhatConfigNetworks {
+export interface HardhatNetworksConfig {
   [key: string]: {
     accounts: { mnemonic: '' };
     chainId: number;
@@ -41,11 +41,15 @@ export interface HardhatConfigNetworks {
   }
 }
 
-export interface HardhatEtherscanNetworks {
-  apiKey: { [etherscanAlias: string]: string; }
-  customChains: {
-    network: string;
-    chainId: number;
-    urls: { apiURL: string; browserURL: string; }
-  }[]
+// https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify#adding-support-for-other-networks
+export interface HardhatEtherscanCustomChain {
+  network: string;
+  chainId: number;
+  urls: { apiURL: string; browserURL: string; }
 }
+
+export interface HardhatEtherscanConfig {
+  apiKey: { [alias: string]: string; }
+  customChains: HardhatEtherscanCustomChain[];
+}
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,7 @@ export type ChainExplorerAPIKey = z.infer<typeof chainExplorerAPIKeySchema>;
 
 export interface HardhatNetworksConfig {
   [key: string]: {
-    accounts: { mnemonic: '' };
+    accounts: { mnemonic: string };
     chainId: number;
     url: string;
   }

--- a/src/utils/strings.test.ts
+++ b/src/utils/strings.test.ts
@@ -1,0 +1,40 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { toUpperSnakeCase } from './strings';
+
+describe('toUpperSnakeCase', () => {
+  test('converts simple words', () => {
+    const result = toUpperSnakeCase('hello world');
+    assert.equal(result, 'HELLO_WORLD');
+  });
+
+  test('keeps numbers in the string', () => {
+    const result = toUpperSnakeCase('hello world 4');
+    assert.equal(result, 'HELLO_WORLD_4');
+  });
+
+  test('trims leading and trailing whtestespaces', () => {
+    const result = toUpperSnakeCase('  hello world  ');
+    assert.equal(result, 'HELLO_WORLD');
+  });
+
+  test('converts special characters to underscores', () => {
+    const result = toUpperSnakeCase('hello, world!');
+    assert.equal(result, 'HELLO_WORLD');
+  });
+
+  test('converts multiple spaces to single underscores', () => {
+    const result = toUpperSnakeCase('hello  world');
+    assert.equal(result, 'HELLO_WORLD');
+  });
+
+  test('returns an empty string when given an empty string', () => {
+    const result = toUpperSnakeCase('');
+    assert.equal(result, '');
+  });
+
+  test('converts mixed case strings', () => {
+    const result = toUpperSnakeCase('Hello World');
+    assert.equal(result, 'HELLO_WORLD');
+  });
+});

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,0 +1,9 @@
+export function toUpperSnakeCase(input: string): string {
+  return input
+    .trim()
+    .replace(/\s+/g, ' ') // replace multiple spaces with a single space
+    .replace(/[^a-zA-Z0-9\s]+/g, '') // remove all non-alphanumeric characters
+    .split(' ')
+    .join('_')
+    .toUpperCase();
+}


### PR DESCRIPTION
## Overview

I refactored the code around hardhat to address https://github.com/api3dao/chains/issues/15

```ts
// Old
hardhatConfigNetworks();
hardhatEtherscan();

// New
hardhatConfig.networks();
hardhatConfig.etherscan();
``` 

As part of this change, I also updated the expected API key environment variable names from `ETHERSCAN_API_KEY_${chain.alias}` to `ETHERSCAN_API_KEY_${toUpperSnakeCase(chain.alias)}`. This means that environment variables should be changed as follows:

```sh
# Old
ETHERSCAN_API_KEY_arbitrum-goerli-testnet=1234

# New
ETHERSCAN_API_KEY_ARBITRUM_GOERLI_TESTNET=1234
```

Mixing snake & kebab case felt weird to me, but I'm happy to revert if you prefer the former.

The result of this should be that you no longer need the boilerplate code mentioned in the linked issue. It should be as simple as:

```ts
// hardhat.config.js
const api3Chains = require('@api3/chains');

const etherscan = api3Chains.hardhatConfig().etherscan();
const networks = api3Chains.hardhatConfig().networks();

module.exports = {
  ...,
  etherscan,
  networks,
};
```