### PR TITLE
Add optional env variable overrides for network RPC URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ console.log(CHAINS);
 
 Returns an object where the key is each chain's alias and the value is an object that can be used as the `networks` field of [`hardhat.config.js`](https://hardhat.org/hardhat-runner/docs/config).
 
-The `url` value can be overridden with chain specific environment variables. These environment variables take the form of `HARDHAT_HTTP_RPC_URL_${toUpperSnakeCase(chain.alias)}`. e.g. `HARDHAT_HTTP_RPC_URL_ARBITRUM_GOERLI_TESTNET`.
+The default `url` values can be overridden with chain specific environment variables. These environment variables take the form of `HARDHAT_HTTP_RPC_URL_${toUpperSnakeCase(chain.alias)}`. e.g. `HARDHAT_HTTP_RPC_URL_ARBITRUM_GOERLI_TESTNET`.
 
 ```ts
 import { hardhatConfig } from '@api3/chains';

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ console.log(CHAINS);
 
 Returns an object where the key is each chain's alias and the value is an object that can be used as the `networks` field of [`hardhat.config.js`](https://hardhat.org/hardhat-runner/docs/config).
 
+The `url` value can be overridden with chain specific environment variables. These environment variables take the form of `HARDHAT_HTTP_RPC_URL_${toUpperSnakeCase(chain.alias)}`. e.g. `HARDHAT_HTTP_RPC_URL_ARBITRUM_GOERLI_TESTNET`.
+
 ```ts
 import { hardhatConfig } from '@api3/chains';
 console.log(hardhatConfig.networks());
@@ -109,7 +111,7 @@ console.log(hardhatConfig.etherscan());
 
 Returns an array of expected environment variable names for chains that have an API key required for the explorer. The array also includes a single `MNEMONIC` variable that can be used to configure all networks.
 
-NOTE: Each `ETHERSCAN_API_KEY_` environment variable has the chain alias as a suffix, where the alias has been converted to upper snake case.
+NOTE: Each `ETHERSCAN_API_KEY_` and `HARDHAT_HTTP_RPC_URL_` environment variable has the chain alias as a suffix, where the alias has been converted to upper snake case.
 
 ```ts
 import { hardhatConfig } from '@api3/chains';
@@ -118,6 +120,8 @@ console.log(hardhatConfig.getEnvVariableNames());
 [
   'MNEMONIC',
   'ETHERSCAN_API_KEY_ARBITRUM_GOERLI_TESTNET',
+  ...
+  'HARDHAT_HTTP_RPC_URL_ARBITRUM_GOERLI_TESTNET',
   ...
 ]
 */

--- a/src/hardhat-config.ts
+++ b/src/hardhat-config.ts
@@ -3,15 +3,19 @@ import { toUpperSnakeCase } from './utils/strings';
 import { Chain, HardhatEtherscanConfig, HardhatNetworksConfig } from './types';
 
 export function getEnvVariableNames(): string[] {
-  const hardhatApiKeyEnvNames = CHAINS.filter((chain) => chain.explorer?.api?.key?.required).map((chain) =>
-    etherscanApiKeyName(chain)
-  );
+  const apiKeyEnvNames = CHAINS.filter((chain) => chain.explorer?.api?.key?.required).map((chain) => etherscanApiKeyName(chain));
 
-  return ['MNEMONIC', ...hardhatApiKeyEnvNames];
+  const networkRpcUrlNames = CHAINS.map((chain) => chain.providerUrl);
+
+  return ['MNEMONIC', ...apiKeyEnvNames, ...networkRpcUrlNames];
 }
 
 export function etherscanApiKeyName(chain: Chain): string {
   return `ETHERSCAN_API_KEY_${toUpperSnakeCase(chain.alias)}`;
+}
+
+export function networkHttpRpcUrlName(chain: Chain): string {
+  return `HARDHAT_HTTP_RPC_URL_${toUpperSnakeCase(chain.alias)}`;
 }
 
 // https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify#multiple-api-keys-and-alternative-block-explorers
@@ -62,7 +66,7 @@ export function networks(): HardhatNetworksConfig {
     networks[chain.alias] = {
       accounts: { mnemonic: process.env.MNEMONIC || '' },
       chainId: Number(chain.id),
-      url: chain.providerUrl,
+      url: process.env[networkHttpRpcUrlName(chain)] || chain.providerUrl,
     };
     return networks;
   }, {} as HardhatNetworksConfig);


### PR DESCRIPTION
## Changes

1. Adds the ability to override URL values when generating Hardhat networks. These optional env variables have the form of `HARDHAT_HTTP_RPC_URL_${toUpperSnakeCase(chain)}` and are also included in the list of environment variables from `getEnvVariableNames()`.

Resolves: https://github.com/api3dao/chains/issues/51

@bbenligiray I'm not sure I understand [this comment](https://github.com/api3dao/chains/issues/51#issuecomment-1635845801) though. This repo no longer does any `.env`/`.env.example` generation.