### PR TITLE
Fix generate-chains script to work with Prettier v3

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Run Build
+        run: yarn build
+
       - name: Run Linting Checks
         run: yarn lint
 
@@ -60,4 +63,3 @@ jobs:
     needs: [documentation, lint-test]
     steps:
       - run: exit 0
-

--- a/scripts/generate-chains.ts
+++ b/scripts/generate-chains.ts
@@ -33,7 +33,7 @@ async function mergeJsonFiles(): Promise<void> {
   const rawContent = `${HEADER_CONTENT}\nexport const CHAINS: Chain[] = ${JSON.stringify(combinedChains)};\n\n`;
 
   const prettierConfig = JSON.parse(fs.readFileSync(PRETTIER_CONFIG, 'utf-8'));
-  const formattedContent = await prettier.format(rawContent, { parser: 'typescript', ...prettierConfig });
+  const formattedContent = await prettier.format(rawContent, { ...prettierConfig, parser: 'typescript' });
 
   if (!fs.existsSync(OUTPUT_DIR)) {
     fs.mkdirSync(OUTPUT_DIR);

--- a/scripts/generate-chains.ts
+++ b/scripts/generate-chains.ts
@@ -18,7 +18,7 @@ const HEADER_CONTENT = `// =====================================================
 import { Chain } from '../types';
 `;
 
-function mergeJsonFiles(): void {
+async function mergeJsonFiles(): Promise<void> {
   const fileNames = fs.readdirSync(INPUT_DIR);
   const jsonFiles = fileNames.filter((fileName) => fileName.endsWith('.json'));
   const combinedChains: any = [];
@@ -33,7 +33,7 @@ function mergeJsonFiles(): void {
   const rawContent = `${HEADER_CONTENT}\nexport const CHAINS: Chain[] = ${JSON.stringify(combinedChains)};\n\n`;
 
   const prettierConfig = JSON.parse(fs.readFileSync(PRETTIER_CONFIG, 'utf-8'));
-  const formattedContent = prettier.format(rawContent, { parser: 'typescript', ...prettierConfig });
+  const formattedContent = await prettier.format(rawContent, { parser: 'typescript', ...prettierConfig });
 
   if (!fs.existsSync(OUTPUT_DIR)) {
     fs.mkdirSync(OUTPUT_DIR);
@@ -66,7 +66,13 @@ function watchJsonFiles(): void {
 
 if (process.argv.includes('--watch')) {
   watchJsonFiles();
+  
 } else {
-  mergeJsonFiles();
+  mergeJsonFiles()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      console.log(error);
+      process.exit(1);
+    });
 }
 

--- a/scripts/generate-chains.ts
+++ b/scripts/generate-chains.ts
@@ -66,7 +66,6 @@ function watchJsonFiles(): void {
 
 if (process.argv.includes('--watch')) {
   watchJsonFiles();
-  
 } else {
   mergeJsonFiles()
     .then(() => process.exit(0))


### PR DESCRIPTION
Apologies I missed that upgrading to Prettier v3 broke the `generate-chains` script. I've adjusted the script to be async now that the exposed Prettier functions return promises.