### PR TITLE
Fix the environment variable names for hardhat RPC URLs

### DIFF
--- a/src/hardhat-config.ts
+++ b/src/hardhat-config.ts
@@ -7,7 +7,7 @@ export function getEnvVariableNames(): string[] {
     etherscanApiKeyName(chain)
   );
 
-  const networkRpcUrlNames = CHAINS.map((chain) => chain.providerUrl);
+  const networkRpcUrlNames = CHAINS.map((chain) => networkHttpRpcUrlName(chain));
 
   return ['MNEMONIC', ...apiKeyEnvNames, ...networkRpcUrlNames];
 }


### PR DESCRIPTION
I distinctly remember testing https://github.com/api3dao/chains/pull/53 so I have no idea how this happened. Maybe I entered the environment variable manually and only tested that it overrides the default but not this function.