### PR TITLE
Fix gnosis testnet explorer urls

### DIFF
--- a/chains/gnosis-testnet.json
+++ b/chains/gnosis-testnet.json
@@ -7,13 +7,13 @@
   "providerUrl": "https://rpc.chiadochain.net",
   "explorer": {
     "api": {
-      "url": "https://blockscout.chiadochain.net/api",
+      "url": "https://gnosis-chiado.blockscout.com/api",
       "key": {
         "required": false,
         "hardhatEtherscanAlias": "chiado"
       }
     },
-    "browserUrl": "https://blockscout.com/gnosis/chiado/"
+    "browserUrl": "https://gnosis-chiado.blockscout.com/"
   },
   "blockTimeMs": 5015
 }

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -288,8 +288,11 @@ export const CHAINS: Chain[] = [
     testnet: true,
     providerUrl: 'https://rpc.chiadochain.net',
     explorer: {
-      api: { url: 'https://blockscout.chiadochain.net/api', key: { required: false, hardhatEtherscanAlias: 'chiado' } },
-      browserUrl: 'https://blockscout.com/gnosis/chiado/',
+      api: {
+        url: 'https://gnosis-chiado.blockscout.com/api',
+        key: { required: false, hardhatEtherscanAlias: 'chiado' },
+      },
+      browserUrl: 'https://gnosis-chiado.blockscout.com/',
     },
     blockTimeMs: 5015,
   },


### PR DESCRIPTION
They've updated it but the API still doesn't work :/