### PR TITLE
Fix kava explorer urls

### DIFF
--- a/chains/kava-testnet.json
+++ b/chains/kava-testnet.json
@@ -7,12 +7,12 @@
   "providerUrl": "https://evm.testnet.kava.io/",
   "explorer": {
     "api": {
-      "url": "https://explorer.testnet.kava.io/api",
+      "url": "https://testnet.kavascan.com/api",
       "key": {
         "required": false
       }
     },
-    "browserUrl": "https://explorer.testnet.kava.io/"
+    "browserUrl": "https://testnet.kavascan.com/"
   },
   "blockTimeMs": 5201
 }

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -334,8 +334,8 @@ export const CHAINS: Chain[] = [
     testnet: true,
     providerUrl: 'https://evm.testnet.kava.io/',
     explorer: {
-      api: { url: 'https://explorer.testnet.kava.io/api', key: { required: false } },
-      browserUrl: 'https://explorer.testnet.kava.io/',
+      api: { url: 'https://testnet.kavascan.com/api', key: { required: false } },
+      browserUrl: 'https://testnet.kavascan.com/',
     },
     blockTimeMs: 5201,
   },


### PR DESCRIPTION
This one is an actual fix. Oddly enough kavascan.com takes you to a blockscout instance.