### PR TITLE
Use providers array instead providerUrl

### DIFF
--- a/chains/arbitrum-goerli-testnet.json
+++ b/chains/arbitrum-goerli-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "arbitrum",
+      "alias": "default",
       "rpcUrl": "https://goerli-rollup.arbitrum.io/rpc"
     }
   ],

--- a/chains/arbitrum-goerli-testnet.json
+++ b/chains/arbitrum-goerli-testnet.json
@@ -4,7 +4,12 @@
   "id": "421613",
   "symbol": "testETH",
   "testnet": true,
-  "providerUrl": "https://goerli-rollup.arbitrum.io/rpc",
+  "providers": [
+    {
+      "alias": "arbitrum",
+      "rpcUrl": "https://goerli-rollup.arbitrum.io/rpc"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api-goerli.arbiscan.io/api",

--- a/chains/arbitrum-nova.json
+++ b/chains/arbitrum-nova.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "arbitrum",
+      "alias": "default",
       "rpcUrl": "https://nova.arbitrum.io/rpc"
     }
   ],

--- a/chains/arbitrum-nova.json
+++ b/chains/arbitrum-nova.json
@@ -4,7 +4,12 @@
   "id": "42170",
   "symbol": "ETH",
   "testnet": false,
-  "providerUrl": "https://nova.arbitrum.io/rpc",
+  "providers": [
+    {
+      "alias": "arbitrum",
+      "rpcUrl": "https://nova.arbitrum.io/rpc"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api-nova.arbiscan.io/api",

--- a/chains/arbitrum.json
+++ b/chains/arbitrum.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "arbitrum",
+      "alias": "default",
       "rpcUrl": "https://arb1.arbitrum.io/rpc"
     }
   ],

--- a/chains/arbitrum.json
+++ b/chains/arbitrum.json
@@ -4,7 +4,12 @@
   "id": "42161",
   "symbol": "ETH",
   "testnet": false,
-  "providerUrl": "https://arb1.arbitrum.io/rpc",
+  "providers": [
+    {
+      "alias": "arbitrum",
+      "rpcUrl": "https://arb1.arbitrum.io/rpc"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api.arbiscan.io/api",

--- a/chains/aurora-testnet.json
+++ b/chains/aurora-testnet.json
@@ -4,7 +4,12 @@
   "id": "1313161555",
   "symbol": "testETH",
   "testnet": true,
-  "providerUrl": "https://testnet.aurora.dev/",
+  "providers": [
+    {
+      "alias": "aurora",
+      "rpcUrl": "https://testnet.aurora.dev/"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://explorer.testnet.aurora.dev/api",

--- a/chains/aurora-testnet.json
+++ b/chains/aurora-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "aurora",
+      "alias": "default",
       "rpcUrl": "https://testnet.aurora.dev/"
     }
   ],

--- a/chains/aurora.json
+++ b/chains/aurora.json
@@ -4,7 +4,12 @@
   "id": "1313161554",
   "symbol": "ETH",
   "testnet": false,
-  "providerUrl": "https://mainnet.aurora.dev/",
+  "providers": [
+    {
+      "alias": "aurora",
+      "rpcUrl": "https://mainnet.aurora.dev/"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://explorer.mainnet.aurora.dev/api",

--- a/chains/aurora.json
+++ b/chains/aurora.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "aurora",
+      "alias": "default",
       "rpcUrl": "https://mainnet.aurora.dev/"
     }
   ],

--- a/chains/avalanche-testnet.json
+++ b/chains/avalanche-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "avalanche",
+      "alias": "avax-test",
       "rpcUrl": "https://api.avax-test.network/ext/bc/C/rpc"
     }
   ],

--- a/chains/avalanche-testnet.json
+++ b/chains/avalanche-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "avax-test",
+      "alias": "default",
       "rpcUrl": "https://api.avax-test.network/ext/bc/C/rpc"
     }
   ],

--- a/chains/avalanche-testnet.json
+++ b/chains/avalanche-testnet.json
@@ -4,7 +4,12 @@
   "id": "43113",
   "symbol": "testAVAX",
   "testnet": true,
-  "providerUrl": "https://api.avax-test.network/ext/bc/C/rpc",
+  "providers": [
+    {
+      "alias": "avalanche",
+      "rpcUrl": "https://api.avax-test.network/ext/bc/C/rpc"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api-testnet.snowtrace.io/api",

--- a/chains/avalanche.json
+++ b/chains/avalanche.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "avax",
+      "alias": "default",
       "rpcUrl": "https://api.avax.network/ext/bc/C/rpc"
     }
   ],

--- a/chains/avalanche.json
+++ b/chains/avalanche.json
@@ -4,7 +4,12 @@
   "id": "43114",
   "symbol": "AVAX",
   "testnet": false,
-  "providerUrl": "https://api.avax.network/ext/bc/C/rpc",
+  "providers": [
+    {
+      "alias": "avalanche",
+      "rpcUrl": "https://api.avax.network/ext/bc/C/rpc"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api.snowtrace.io/api",

--- a/chains/avalanche.json
+++ b/chains/avalanche.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "avalanche",
+      "alias": "avax",
       "rpcUrl": "https://api.avax.network/ext/bc/C/rpc"
     }
   ],

--- a/chains/base-goerli-testnet.json
+++ b/chains/base-goerli-testnet.json
@@ -4,7 +4,12 @@
   "id": "84531",
   "symbol": "testETH",
   "testnet": true,
-  "providerUrl": "https://goerli.base.org",
+  "providers": [
+    {
+      "alias": "base",
+      "rpcUrl": "https://goerli.base.org"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api-goerli.basescan.org/api",

--- a/chains/base-goerli-testnet.json
+++ b/chains/base-goerli-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "base",
+      "alias": "default",
       "rpcUrl": "https://goerli.base.org"
     }
   ],

--- a/chains/base.json
+++ b/chains/base.json
@@ -4,7 +4,12 @@
   "id": "8453",
   "symbol": "ETH",
   "testnet": false,
-  "providerUrl": "https://mainnet.base.org",
+  "providers": [
+    {
+      "alias": "base",
+      "rpcUrl": "https://mainnet.base.org"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api.basescan.org/api",

--- a/chains/base.json
+++ b/chains/base.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "base",
+      "alias": "default",
       "rpcUrl": "https://mainnet.base.org"
     }
   ],

--- a/chains/boba-avalanche.json
+++ b/chains/boba-avalanche.json
@@ -4,7 +4,12 @@
   "id": "43288",
   "symbol": "BOBA",
   "testnet": false,
-  "providerUrl": "https://replica.avax.boba.network/",
+  "providers": [
+    {
+      "alias": "boba",
+      "rpcUrl": "https://replica.avax.boba.network/"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://blockexplorer.avax.boba.network/api",

--- a/chains/boba-avalanche.json
+++ b/chains/boba-avalanche.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "boba",
+      "alias": "default",
       "rpcUrl": "https://replica.avax.boba.network/"
     }
   ],

--- a/chains/boba-bnb.json
+++ b/chains/boba-bnb.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "boba",
+      "alias": "default",
       "rpcUrl": "https://replica.bnb.boba.network/"
     }
   ],

--- a/chains/boba-bnb.json
+++ b/chains/boba-bnb.json
@@ -4,7 +4,12 @@
   "id": "56288",
   "symbol": "BOBA",
   "testnet": false,
-  "providerUrl": "https://replica.bnb.boba.network/",
+  "providers": [
+    {
+      "alias": "boba",
+      "rpcUrl": "https://replica.bnb.boba.network/"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://blockexplorer.bnb.boba.network/api",

--- a/chains/boba-ethereum.json
+++ b/chains/boba-ethereum.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "boba",
+      "alias": "default",
       "rpcUrl": "https://lightning-replica.boba.network/"
     }
   ],

--- a/chains/boba-ethereum.json
+++ b/chains/boba-ethereum.json
@@ -4,7 +4,12 @@
   "id": "288",
   "symbol": "BOBA",
   "testnet": false,
-  "providerUrl": "https://lightning-replica.boba.network/",
+  "providers": [
+    {
+      "alias": "boba",
+      "rpcUrl": "https://lightning-replica.boba.network/"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api.bobascan.com/api",

--- a/chains/bsc-testnet.json
+++ b/chains/bsc-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "binance",
+      "alias": "default",
       "rpcUrl": "https://data-seed-prebsc-1-s3.binance.org:8545/"
     }
   ],

--- a/chains/bsc-testnet.json
+++ b/chains/bsc-testnet.json
@@ -4,7 +4,12 @@
   "id": "97",
   "symbol": "testBNB",
   "testnet": true,
-  "providerUrl": "https://data-seed-prebsc-1-s3.binance.org:8545/",
+  "providers": [
+    {
+      "alias": "binance",
+      "rpcUrl": "https://data-seed-prebsc-1-s3.binance.org:8545/"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api-testnet.bscscan.com/api",

--- a/chains/bsc.json
+++ b/chains/bsc.json
@@ -4,7 +4,12 @@
   "id": "56",
   "symbol": "BNB",
   "testnet": false,
-  "providerUrl": "https://rpc.ankr.com/bsc",
+  "providers": [
+    {
+      "alias": "ankr",
+      "rpcUrl": "https://rpc.ankr.com/bsc"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api.bscscan.com/api",

--- a/chains/bsc.json
+++ b/chains/bsc.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "ankr",
+      "alias": "default",
       "rpcUrl": "https://rpc.ankr.com/bsc"
     }
   ],

--- a/chains/cronos-testnet.json
+++ b/chains/cronos-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "cronos",
+      "alias": "default",
       "rpcUrl": "https://evm-t3.cronos.org"
     }
   ],

--- a/chains/cronos-testnet.json
+++ b/chains/cronos-testnet.json
@@ -4,7 +4,12 @@
   "id": "338",
   "symbol": "testCRO",
   "testnet": true,
-  "providerUrl": "https://evm-t3.cronos.org",
+  "providers": [
+    {
+      "alias": "cronos",
+      "rpcUrl": "https://evm-t3.cronos.org"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://cronos.org/explorer/testnet3/api",

--- a/chains/ethereum-goerli-testnet.json
+++ b/chains/ethereum-goerli-testnet.json
@@ -4,7 +4,12 @@
   "id": "5",
   "symbol": "testETH",
   "testnet": true,
-  "providerUrl": "https://rpc.ankr.com/eth_goerli",
+  "providers": [
+    {
+      "alias": "ankr",
+      "rpcUrl": "https://rpc.ankr.com/eth_goerli"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api-goerli.etherscan.io/api",

--- a/chains/ethereum-goerli-testnet.json
+++ b/chains/ethereum-goerli-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "ankr",
+      "alias": "default",
       "rpcUrl": "https://rpc.ankr.com/eth_goerli"
     }
   ],

--- a/chains/ethereum-sepolia-testnet.json
+++ b/chains/ethereum-sepolia-testnet.json
@@ -4,7 +4,12 @@
   "id": "11155111",
   "symbol": "testETH",
   "testnet": true,
-  "providerUrl": "https://rpc-sepolia.rockx.com",
+  "providers": [
+    {
+      "alias": "rockx",
+      "rpcUrl": "https://rpc-sepolia.rockx.com"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api-sepolia.etherscan.io/api",

--- a/chains/ethereum-sepolia-testnet.json
+++ b/chains/ethereum-sepolia-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "rockx",
+      "alias": "default",
       "rpcUrl": "https://rpc-sepolia.rockx.com"
     }
   ],

--- a/chains/ethereum.json
+++ b/chains/ethereum.json
@@ -4,7 +4,12 @@
   "id": "1",
   "symbol": "ETH",
   "testnet": false,
-  "providerUrl": "https://eth.llamarpc.com",
+  "providers": [
+    {
+      "alias": "llamarpc",
+      "rpcUrl": "https://eth.llamarpc.com"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api.etherscan.io/api",

--- a/chains/ethereum.json
+++ b/chains/ethereum.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "llamarpc",
+      "alias": "default",
       "rpcUrl": "https://eth.llamarpc.com"
     }
   ],

--- a/chains/fantom-testnet.json
+++ b/chains/fantom-testnet.json
@@ -4,7 +4,12 @@
   "id": "4002",
   "symbol": "testFTM",
   "testnet": true,
-  "providerUrl": "https://rpc.ankr.com/fantom_testnet",
+  "providers": [
+    {
+      "alias": "ankr",
+      "rpcUrl": "https://rpc.ankr.com/fantom_testnet"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api-testnet.ftmscan.com/api",

--- a/chains/fantom-testnet.json
+++ b/chains/fantom-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "ankr",
+      "alias": "default",
       "rpcUrl": "https://rpc.ankr.com/fantom_testnet"
     }
   ],

--- a/chains/fantom.json
+++ b/chains/fantom.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "fantom",
+      "alias": "default",
       "rpcUrl": "https://rpcapi.fantom.network/"
     }
   ],

--- a/chains/fantom.json
+++ b/chains/fantom.json
@@ -4,7 +4,12 @@
   "id": "250",
   "symbol": "FTM",
   "testnet": false,
-  "providerUrl": "https://rpcapi.fantom.network/",
+  "providers": [
+    {
+      "alias": "fantom",
+      "rpcUrl": "https://rpcapi.fantom.network/"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api.ftmscan.com/api",

--- a/chains/gnosis-testnet.json
+++ b/chains/gnosis-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "chiadochain",
+      "alias": "default",
       "rpcUrl": "https://rpc.chiadochain.net"
     }
   ],

--- a/chains/gnosis-testnet.json
+++ b/chains/gnosis-testnet.json
@@ -4,7 +4,12 @@
   "id": "10200",
   "symbol": "testxDAI",
   "testnet": true,
-  "providerUrl": "https://rpc.chiadochain.net",
+  "providers": [
+    {
+      "alias": "chiadochain",
+      "rpcUrl": "https://rpc.chiadochain.net"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://gnosis-chiado.blockscout.com/api",

--- a/chains/gnosis.json
+++ b/chains/gnosis.json
@@ -4,7 +4,12 @@
   "id": "100",
   "symbol": "xDAI",
   "testnet": false,
-  "providerUrl": "https://rpc.gnosischain.com",
+  "providers": [
+    {
+      "alias": "gnosischain",
+      "rpcUrl": "https://rpc.gnosischain.com"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api.gnosisscan.io/api",

--- a/chains/gnosis.json
+++ b/chains/gnosis.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "gnosischain",
+      "alias": "default",
       "rpcUrl": "https://rpc.gnosischain.com"
     }
   ],

--- a/chains/godwoken-testnet.json
+++ b/chains/godwoken-testnet.json
@@ -4,7 +4,12 @@
   "id": "71401",
   "symbol": "testpCKB",
   "testnet": true,
-  "providerUrl": "https://v1.testnet.godwoken.io/rpc",
+  "providers": [
+    {
+      "alias": "godwoken",
+      "rpcUrl": "https://v1.testnet.godwoken.io/rpc"
+    }
+  ],
   "explorer": {
     "browserUrl": "https://v1.testnet.gwscan.com/"
   },

--- a/chains/godwoken-testnet.json
+++ b/chains/godwoken-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "godwoken",
+      "alias": "default",
       "rpcUrl": "https://v1.testnet.godwoken.io/rpc"
     }
   ],

--- a/chains/godwoken.json
+++ b/chains/godwoken.json
@@ -4,7 +4,12 @@
   "id": "71402",
   "symbol": "pCKB",
   "testnet": false,
-  "providerUrl": "https://v1.mainnet.godwoken.io/rpc",
+  "providers": [
+    {
+      "alias": "godwoken",
+      "rpcUrl": "https://v1.mainnet.godwoken.io/rpc"
+    }
+  ],
   "explorer": {
     "browserUrl": "https://v1.gwscan.com/"
   },

--- a/chains/godwoken.json
+++ b/chains/godwoken.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "godwoken",
+      "alias": "default",
       "rpcUrl": "https://v1.mainnet.godwoken.io/rpc"
     }
   ],

--- a/chains/kava-testnet.json
+++ b/chains/kava-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "kava",
+      "alias": "default",
       "rpcUrl": "https://evm.testnet.kava.io/"
     }
   ],

--- a/chains/kava-testnet.json
+++ b/chains/kava-testnet.json
@@ -4,7 +4,12 @@
   "id": "2221",
   "symbol": "testKAVA",
   "testnet": true,
-  "providerUrl": "https://evm.testnet.kava.io/",
+  "providers": [
+    {
+      "alias": "kava",
+      "rpcUrl": "https://evm.testnet.kava.io/"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://testnet.kavascan.com/api",

--- a/chains/kava.json
+++ b/chains/kava.json
@@ -4,7 +4,12 @@
   "id": "2222",
   "symbol": "KAVA",
   "testnet": false,
-  "providerUrl": "https://evm.kava.io/",
+  "providers": [
+    {
+      "alias": "kava",
+      "rpcUrl": "https://evm.kava.io/"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://kavascan.com/api",

--- a/chains/kava.json
+++ b/chains/kava.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "kava",
+      "alias": "default",
       "rpcUrl": "https://evm.kava.io/"
     }
   ],

--- a/chains/linea-goerli-testnet.json
+++ b/chains/linea-goerli-testnet.json
@@ -4,7 +4,12 @@
   "id": "59140",
   "symbol": "testETH",
   "testnet": true,
-  "providerUrl": "https://rpc.goerli.linea.build",
+  "providers": [
+    {
+      "alias": "linea",
+      "rpcUrl": "https://rpc.goerli.linea.build"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api-testnet.lineascan.build/api",

--- a/chains/linea-goerli-testnet.json
+++ b/chains/linea-goerli-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "linea",
+      "alias": "default",
       "rpcUrl": "https://rpc.goerli.linea.build"
     }
   ],

--- a/chains/linea.json
+++ b/chains/linea.json
@@ -4,7 +4,12 @@
   "id": "59144",
   "symbol": "ETH",
   "testnet": false,
-  "providerUrl": "https://rpc.linea.build",
+  "providers": [
+    {
+      "alias": "linea",
+      "rpcUrl": "https://rpc.linea.build"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api.lineascan.build/api",

--- a/chains/linea.json
+++ b/chains/linea.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "linea",
+      "alias": "default",
       "rpcUrl": "https://rpc.linea.build"
     }
   ],

--- a/chains/mantle-goerli-testnet.json
+++ b/chains/mantle-goerli-testnet.json
@@ -4,7 +4,12 @@
   "id": "5001",
   "symbol": "MNT",
   "testnet": true,
-  "providerUrl": "https://rpc.testnet.mantle.xyz",
+  "providers": [
+    {
+      "alias": "mantle",
+      "rpcUrl": "https://rpc.testnet.mantle.xyz"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://explorer.testnet.mantle.xyz/api",

--- a/chains/mantle-goerli-testnet.json
+++ b/chains/mantle-goerli-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "mantle",
+      "alias": "default",
       "rpcUrl": "https://rpc.testnet.mantle.xyz"
     }
   ],

--- a/chains/mantle.json
+++ b/chains/mantle.json
@@ -4,7 +4,12 @@
   "id": "5000",
   "symbol": "MNT",
   "testnet": false,
-  "providerUrl": "https://rpc.mantle.xyz",
+  "providers": [
+    {
+      "alias": "mantle",
+      "rpcUrl": "https://rpc.mantle.xyz"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://explorer.mantle.xyz/api",

--- a/chains/mantle.json
+++ b/chains/mantle.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "mantle",
+      "alias": "default",
       "rpcUrl": "https://rpc.mantle.xyz"
     }
   ],

--- a/chains/metis-goerli-testnet.json
+++ b/chains/metis-goerli-testnet.json
@@ -4,7 +4,12 @@
   "id": "599",
   "symbol": "testMETIS",
   "testnet": true,
-  "providerUrl": "https://goerli.gateway.metisdevops.link",
+  "providers": [
+    {
+      "alias": "metisdevops",
+      "rpcUrl": "https://goerli.gateway.metisdevops.link"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://goerli.explorer.metisdevops.link/api",

--- a/chains/metis-goerli-testnet.json
+++ b/chains/metis-goerli-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "metisdevops",
+      "alias": "default",
       "rpcUrl": "https://goerli.gateway.metisdevops.link"
     }
   ],

--- a/chains/metis.json
+++ b/chains/metis.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "metis",
+      "alias": "default",
       "rpcUrl": "https://andromeda.metis.io/?owner=1088"
     }
   ],

--- a/chains/metis.json
+++ b/chains/metis.json
@@ -4,7 +4,12 @@
   "id": "1088",
   "symbol": "METIS",
   "testnet": false,
-  "providerUrl": "https://andromeda.metis.io/?owner=1088",
+  "providers": [
+    {
+      "alias": "metis",
+      "rpcUrl": "https://andromeda.metis.io/?owner=1088"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://andromeda-explorer.metis.io/api",

--- a/chains/milkomeda-c1-testnet.json
+++ b/chains/milkomeda-c1-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "milkomeda",
+      "alias": "default",
       "rpcUrl": "https://rpc-devnet-cardano-evm.c1.milkomeda.com"
     }
   ],

--- a/chains/milkomeda-c1-testnet.json
+++ b/chains/milkomeda-c1-testnet.json
@@ -4,7 +4,12 @@
   "id": "200101",
   "symbol": "testmilkADA",
   "testnet": true,
-  "providerUrl": "https://rpc-devnet-cardano-evm.c1.milkomeda.com",
+  "providers": [
+    {
+      "alias": "milkomeda",
+      "rpcUrl": "https://rpc-devnet-cardano-evm.c1.milkomeda.com"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://explorer-devnet-cardano-evm.c1.milkomeda.com/api",

--- a/chains/milkomeda-c1.json
+++ b/chains/milkomeda-c1.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "milkomeda",
+      "alias": "default",
       "rpcUrl": "https://rpc-mainnet-cardano-evm.c1.milkomeda.com"
     }
   ],

--- a/chains/milkomeda-c1.json
+++ b/chains/milkomeda-c1.json
@@ -4,7 +4,12 @@
   "id": "2001",
   "symbol": "milkADA",
   "testnet": false,
-  "providerUrl": "https://rpc-mainnet-cardano-evm.c1.milkomeda.com",
+  "providers": [
+    {
+      "alias": "milkomeda",
+      "rpcUrl": "https://rpc-mainnet-cardano-evm.c1.milkomeda.com"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://explorer-mainnet-cardano-evm.c1.milkomeda.com/api",

--- a/chains/moonbeam-testnet.json
+++ b/chains/moonbeam-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "moonbeam",
+      "alias": "default",
       "rpcUrl": "https://rpc.api.moonbase.moonbeam.network"
     }
   ],

--- a/chains/moonbeam-testnet.json
+++ b/chains/moonbeam-testnet.json
@@ -4,7 +4,12 @@
   "id": "1287",
   "symbol": "testGLMR",
   "testnet": true,
-  "providerUrl": "https://rpc.api.moonbase.moonbeam.network",
+  "providers": [
+    {
+      "alias": "moonbeam",
+      "rpcUrl": "https://rpc.api.moonbase.moonbeam.network"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api-moonbase.moonscan.io/api",

--- a/chains/moonbeam.json
+++ b/chains/moonbeam.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "moonbeam",
+      "alias": "default",
       "rpcUrl": "https://rpc.api.moonbeam.network"
     }
   ],

--- a/chains/moonbeam.json
+++ b/chains/moonbeam.json
@@ -4,7 +4,12 @@
   "id": "1284",
   "symbol": "GLMR",
   "testnet": false,
-  "providerUrl": "https://rpc.api.moonbeam.network",
+  "providers": [
+    {
+      "alias": "moonbeam",
+      "rpcUrl": "https://rpc.api.moonbeam.network"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api-moonbeam.moonscan.io/api",

--- a/chains/moonriver.json
+++ b/chains/moonriver.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "moonbeam",
+      "alias": "default",
       "rpcUrl": "https://rpc.api.moonriver.moonbeam.network"
     }
   ],

--- a/chains/moonriver.json
+++ b/chains/moonriver.json
@@ -4,7 +4,12 @@
   "id": "1285",
   "symbol": "MOVR",
   "testnet": false,
-  "providerUrl": "https://rpc.api.moonriver.moonbeam.network",
+  "providers": [
+    {
+      "alias": "moonbeam",
+      "rpcUrl": "https://rpc.api.moonriver.moonbeam.network"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api-moonriver.moonscan.io/api",

--- a/chains/optimism-goerli-testnet.json
+++ b/chains/optimism-goerli-testnet.json
@@ -4,7 +4,12 @@
   "id": "420",
   "symbol": "testETH",
   "testnet": true,
-  "providerUrl": "https://goerli.optimism.io",
+  "providers": [
+    {
+      "alias": "optimism",
+      "rpcUrl": "https://goerli.optimism.io"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api-goerli-optimism.etherscan.io/api",

--- a/chains/optimism-goerli-testnet.json
+++ b/chains/optimism-goerli-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "optimism",
+      "alias": "default",
       "rpcUrl": "https://goerli.optimism.io"
     }
   ],

--- a/chains/optimism.json
+++ b/chains/optimism.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "optimism",
+      "alias": "default",
       "rpcUrl": "https://mainnet.optimism.io"
     }
   ],

--- a/chains/optimism.json
+++ b/chains/optimism.json
@@ -4,7 +4,12 @@
   "id": "10",
   "symbol": "ETH",
   "testnet": false,
-  "providerUrl": "https://mainnet.optimism.io",
+  "providers": [
+    {
+      "alias": "optimism",
+      "rpcUrl": "https://mainnet.optimism.io"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api-optimistic.etherscan.io/api",

--- a/chains/polygon-testnet.json
+++ b/chains/polygon-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "ankr",
+      "alias": "default",
       "rpcUrl": "https://rpc.ankr.com/polygon_mumbai"
     }
   ],

--- a/chains/polygon-testnet.json
+++ b/chains/polygon-testnet.json
@@ -4,7 +4,12 @@
   "id": "80001",
   "symbol": "testMATIC",
   "testnet": true,
-  "providerUrl": "https://rpc.ankr.com/polygon_mumbai",
+  "providers": [
+    {
+      "alias": "ankr",
+      "rpcUrl": "https://rpc.ankr.com/polygon_mumbai"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api-testnet.polygonscan.com/api",

--- a/chains/polygon-zkevm-goerli-testnet.json
+++ b/chains/polygon-zkevm-goerli-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "zkevm-test",
+      "alias": "default",
       "rpcUrl": "https://rpc.public.zkevm-test.net"
     }
   ],

--- a/chains/polygon-zkevm-goerli-testnet.json
+++ b/chains/polygon-zkevm-goerli-testnet.json
@@ -4,7 +4,12 @@
   "id": "1442",
   "symbol": "testETH",
   "testnet": true,
-  "providerUrl": "https://rpc.public.zkevm-test.net",
+  "providers": [
+    {
+      "alias": "zkevm-test",
+      "rpcUrl": "https://rpc.public.zkevm-test.net"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api-testnet-zkevm.polygonscan.com/api",

--- a/chains/polygon-zkevm.json
+++ b/chains/polygon-zkevm.json
@@ -4,7 +4,12 @@
   "id": "1101",
   "symbol": "ETH",
   "testnet": false,
-  "providerUrl": "https://zkevm-rpc.com",
+  "providers": [
+    {
+      "alias": "zkevm-rpc",
+      "rpcUrl": "https://zkevm-rpc.com"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api-zkevm.polygonscan.com/api",

--- a/chains/polygon-zkevm.json
+++ b/chains/polygon-zkevm.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "zkevm-rpc",
+      "alias": "default",
       "rpcUrl": "https://zkevm-rpc.com"
     }
   ],

--- a/chains/polygon.json
+++ b/chains/polygon.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "ankr",
+      "alias": "default",
       "rpcUrl": "https://rpc.ankr.com/polygon"
     }
   ],

--- a/chains/polygon.json
+++ b/chains/polygon.json
@@ -4,7 +4,12 @@
   "id": "137",
   "symbol": "MATIC",
   "testnet": false,
-  "providerUrl": "https://rpc.ankr.com/polygon",
+  "providers": [
+    {
+      "alias": "ankr",
+      "rpcUrl": "https://rpc.ankr.com/polygon"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://api.polygonscan.com/api",

--- a/chains/rsk-testnet.json
+++ b/chains/rsk-testnet.json
@@ -4,7 +4,12 @@
   "id": "31",
   "symbol": "testRBTC",
   "testnet": true,
-  "providerUrl": "https://public-node.testnet.rsk.co",
+  "providers": [
+    {
+      "alias": "rsk",
+      "rpcUrl": "https://public-node.testnet.rsk.co"
+    }
+  ],
   "explorer": {
     "browserUrl": "https://explorer.testnet.rsk.co/"
   },

--- a/chains/rsk-testnet.json
+++ b/chains/rsk-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "rsk",
+      "alias": "default",
       "rpcUrl": "https://public-node.testnet.rsk.co"
     }
   ],

--- a/chains/rsk.json
+++ b/chains/rsk.json
@@ -4,7 +4,12 @@
   "id": "30",
   "symbol": "RBTC",
   "testnet": false,
-  "providerUrl": "https://mainnet.sovryn.app/rpc",
+  "providers": [
+    {
+      "alias": "sovryn",
+      "rpcUrl": "https://mainnet.sovryn.app/rpc"
+    }
+  ],
   "explorer": {
     "browserUrl": "https://explorer.rsk.co/"
   },

--- a/chains/rsk.json
+++ b/chains/rsk.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "sovryn",
+      "alias": "default",
       "rpcUrl": "https://mainnet.sovryn.app/rpc"
     }
   ],

--- a/chains/scroll-goerli-testnet.json
+++ b/chains/scroll-goerli-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "scroll",
+      "alias": "default",
       "rpcUrl": "https://alpha-rpc.scroll.io/l2"
     }
   ],

--- a/chains/scroll-goerli-testnet.json
+++ b/chains/scroll-goerli-testnet.json
@@ -4,7 +4,12 @@
   "id": "534353",
   "symbol": "testETH",
   "testnet": true,
-  "providerUrl": "https://alpha-rpc.scroll.io/l2",
+  "providers": [
+    {
+      "alias": "scroll",
+      "rpcUrl": "https://alpha-rpc.scroll.io/l2"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://blockscout.scroll.io/api",

--- a/chains/sx-testnet.json
+++ b/chains/sx-testnet.json
@@ -4,7 +4,12 @@
   "id": "647",
   "symbol": "testSX",
   "testnet": true,
-  "providerUrl": "https://rpc.toronto.sx.technology",
+  "providers": [
+    {
+      "alias": "sx",
+      "rpcUrl": "https://rpc.toronto.sx.technology"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://explorer.toronto.sx.technology/api",

--- a/chains/sx-testnet.json
+++ b/chains/sx-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "sx",
+      "alias": "default",
       "rpcUrl": "https://rpc.toronto.sx.technology"
     }
   ],

--- a/chains/sx.json
+++ b/chains/sx.json
@@ -4,7 +4,12 @@
   "id": "416",
   "symbol": "SX",
   "testnet": false,
-  "providerUrl": "https://rpc.sx.technology",
+  "providers": [
+    {
+      "alias": "sx",
+      "rpcUrl": "https://rpc.sx.technology"
+    }
+  ],
   "explorer": {
     "api": {
       "url": "https://explorer.sx.technology/api",

--- a/chains/sx.json
+++ b/chains/sx.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "sx",
+      "alias": "default",
       "rpcUrl": "https://rpc.sx.technology"
     }
   ],

--- a/chains/zksync-goerli-testnet.json
+++ b/chains/zksync-goerli-testnet.json
@@ -6,7 +6,7 @@
   "testnet": true,
   "providers": [
     {
-      "alias": "zksync",
+      "alias": "default",
       "rpcUrl": "https://testnet.era.zksync.dev"
     }
   ],

--- a/chains/zksync-goerli-testnet.json
+++ b/chains/zksync-goerli-testnet.json
@@ -4,7 +4,12 @@
   "id": "280",
   "symbol": "testETH",
   "testnet": true,
-  "providerUrl": "https://testnet.era.zksync.dev",
+  "providers": [
+    {
+      "alias": "zksync",
+      "rpcUrl": "https://testnet.era.zksync.dev"
+    }
+  ],
   "explorer": {
     "browserUrl": "https://goerli.explorer.zksync.io/"
   },

--- a/chains/zksync.json
+++ b/chains/zksync.json
@@ -6,7 +6,7 @@
   "testnet": false,
   "providers": [
     {
-      "alias": "zksync",
+      "alias": "default",
       "rpcUrl": "https://mainnet.era.zksync.io"
     }
   ],

--- a/chains/zksync.json
+++ b/chains/zksync.json
@@ -4,7 +4,12 @@
   "id": "324",
   "symbol": "ETH",
   "testnet": false,
-  "providerUrl": "https://mainnet.era.zksync.io",
+  "providers": [
+    {
+      "alias": "zksync",
+      "rpcUrl": "https://mainnet.era.zksync.io"
+    }
+  ],
   "explorer": {
     "browserUrl": "https://explorer.zksync.io/"
   },

--- a/scripts/calculate-average-block-times.ts
+++ b/scripts/calculate-average-block-times.ts
@@ -11,9 +11,9 @@ const chains = specifiedChain ? [specifiedChain] : CHAINS;
 async function calculateAverageBlockTimes(): Promise<void> {
   const results = await Promise.allSettled(
     chains.map(async (chain) => {
-      // Every provider should have at least 1 publicly accessible rpcUrl
-      const firstProviderRpcUrl = chain.providers.find((p) => p.rpcUrl)?.rpcUrl;
-      const client = createPublicClient({ transport: http(firstProviderRpcUrl!) });
+      // Every chain should have at least a default provider with an RPC URL
+      const defaultProvider = chain.providers.find((p) => p.alias === 'default')!;
+      const client = createPublicClient({ transport: http(defaultProvider.rpcUrl!) });
       const chainId = await client.getChainId();
       if (chainId.toString() !== chain.id) {
         throw new Error(`${chain.alias} provider reports chain ID as ${chainId}, while it is defined as ${chain.id}`);

--- a/scripts/calculate-average-block-times.ts
+++ b/scripts/calculate-average-block-times.ts
@@ -11,7 +11,9 @@ const chains = specifiedChain ? [specifiedChain] : CHAINS;
 async function calculateAverageBlockTimes(): Promise<void> {
   const results = await Promise.allSettled(
     chains.map(async (chain) => {
-      const client = createPublicClient({ transport: http(chain.providerUrl) });
+      // Every provider should have at least 1 publicly accessible rpcUrl
+      const firstProviderRpcUrl = chain.providers.find((p) => p.rpcUrl)?.rpcUrl;
+      const client = createPublicClient({ transport: http(firstProviderRpcUrl!) });
       const chainId = await client.getChainId();
       if (chainId.toString() !== chain.id) {
         throw new Error(`${chain.alias} provider reports chain ID as ${chainId}, while it is defined as ${chain.id}`);

--- a/scripts/ping-providers.ts
+++ b/scripts/ping-providers.ts
@@ -17,9 +17,9 @@ const slackClient = new WebClient(slackToken);
 
 async function main(): Promise<PromiseSettledResult<void>[]> {
   const promises = chains.map(async (chain) => {
-    // Every provider should have at least 1 publicly accessible rpcUrl
-    const firstProviderRpcUrl = chain.providers.find((p) => p.rpcUrl)?.rpcUrl;
-    const client = createPublicClient({ transport: http(firstProviderRpcUrl!) });
+    // Every chain should have at least a default provider with an RPC URL
+    const defaultProvider = chain.providers.find((p) => p.alias === 'default')!;
+    const client = createPublicClient({ transport: http(defaultProvider.rpcUrl!) });
 
     await validateChain(client, chain);
     await go(() => validateLatestBlock(client, chain), { retries: 3, delay: { type: 'static', delayMs: 60_000 } });

--- a/scripts/ping-providers.ts
+++ b/scripts/ping-providers.ts
@@ -17,7 +17,9 @@ const slackClient = new WebClient(slackToken);
 
 async function main(): Promise<PromiseSettledResult<void>[]> {
   const promises = chains.map(async (chain) => {
-    const client = createPublicClient({ transport: http(chain.providerUrl) });
+    // Every provider should have at least 1 publicly accessible rpcUrl
+    const firstProviderRpcUrl = chain.providers.find((p) => p.rpcUrl)?.rpcUrl;
+    const client = createPublicClient({ transport: http(firstProviderRpcUrl!) });
 
     await validateChain(client, chain);
     await go(() => validateLatestBlock(client, chain), { retries: 3, delay: { type: 'static', delayMs: 60_000 } });

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -14,7 +14,7 @@ export const CHAINS: Chain[] = [
     id: '421613',
     symbol: 'testETH',
     testnet: true,
-    providerUrl: 'https://goerli-rollup.arbitrum.io/rpc',
+    providers: [{ alias: 'arbitrum', rpcUrl: 'https://goerli-rollup.arbitrum.io/rpc' }],
     explorer: {
       api: {
         url: 'https://api-goerli.arbiscan.io/api',
@@ -30,7 +30,7 @@ export const CHAINS: Chain[] = [
     id: '42170',
     symbol: 'ETH',
     testnet: false,
-    providerUrl: 'https://nova.arbitrum.io/rpc',
+    providers: [{ alias: 'arbitrum', rpcUrl: 'https://nova.arbitrum.io/rpc' }],
     explorer: {
       api: { url: 'https://api-nova.arbiscan.io/api', key: { required: true } },
       browserUrl: 'https://nova.arbiscan.io/',
@@ -43,7 +43,7 @@ export const CHAINS: Chain[] = [
     id: '42161',
     symbol: 'ETH',
     testnet: false,
-    providerUrl: 'https://arb1.arbitrum.io/rpc',
+    providers: [{ alias: 'arbitrum', rpcUrl: 'https://arb1.arbitrum.io/rpc' }],
     explorer: {
       api: { url: 'https://api.arbiscan.io/api', key: { required: true, hardhatEtherscanAlias: 'arbitrumOne' } },
       browserUrl: 'https://arbiscan.io/',
@@ -56,7 +56,7 @@ export const CHAINS: Chain[] = [
     id: '1313161555',
     symbol: 'testETH',
     testnet: true,
-    providerUrl: 'https://testnet.aurora.dev/',
+    providers: [{ alias: 'aurora', rpcUrl: 'https://testnet.aurora.dev/' }],
     explorer: {
       api: {
         url: 'https://explorer.testnet.aurora.dev/api',
@@ -72,7 +72,7 @@ export const CHAINS: Chain[] = [
     id: '1313161554',
     symbol: 'ETH',
     testnet: false,
-    providerUrl: 'https://mainnet.aurora.dev/',
+    providers: [{ alias: 'aurora', rpcUrl: 'https://mainnet.aurora.dev/' }],
     explorer: {
       api: {
         url: 'https://explorer.mainnet.aurora.dev/api',
@@ -88,7 +88,7 @@ export const CHAINS: Chain[] = [
     id: '43113',
     symbol: 'testAVAX',
     testnet: true,
-    providerUrl: 'https://api.avax-test.network/ext/bc/C/rpc',
+    providers: [{ alias: 'avalanche', rpcUrl: 'https://api.avax-test.network/ext/bc/C/rpc' }],
     explorer: {
       api: {
         url: 'https://api-testnet.snowtrace.io/api',
@@ -104,7 +104,7 @@ export const CHAINS: Chain[] = [
     id: '43114',
     symbol: 'AVAX',
     testnet: false,
-    providerUrl: 'https://api.avax.network/ext/bc/C/rpc',
+    providers: [{ alias: 'avalanche', rpcUrl: 'https://api.avax.network/ext/bc/C/rpc' }],
     explorer: {
       api: { url: 'https://api.snowtrace.io/api', key: { required: true, hardhatEtherscanAlias: 'avalanche' } },
       browserUrl: 'https://snowtrace.io/',
@@ -117,7 +117,7 @@ export const CHAINS: Chain[] = [
     id: '84531',
     symbol: 'testETH',
     testnet: true,
-    providerUrl: 'https://goerli.base.org',
+    providers: [{ alias: 'base', rpcUrl: 'https://goerli.base.org' }],
     explorer: {
       api: { url: 'https://api-goerli.basescan.org/api', key: { required: false } },
       browserUrl: 'https://goerli.basescan.org/',
@@ -130,7 +130,7 @@ export const CHAINS: Chain[] = [
     id: '8453',
     symbol: 'ETH',
     testnet: false,
-    providerUrl: 'https://mainnet.base.org',
+    providers: [{ alias: 'base', rpcUrl: 'https://mainnet.base.org' }],
     explorer: {
       api: { url: 'https://api.basescan.org/api', key: { required: true } },
       browserUrl: 'https://basescan.org/',
@@ -143,7 +143,7 @@ export const CHAINS: Chain[] = [
     id: '43288',
     symbol: 'BOBA',
     testnet: false,
-    providerUrl: 'https://replica.avax.boba.network/',
+    providers: [{ alias: 'boba', rpcUrl: 'https://replica.avax.boba.network/' }],
     explorer: {
       api: { url: 'https://blockexplorer.avax.boba.network/api', key: { required: false } },
       browserUrl: 'https://blockexplorer.avax.boba.network/',
@@ -156,7 +156,7 @@ export const CHAINS: Chain[] = [
     id: '56288',
     symbol: 'BOBA',
     testnet: false,
-    providerUrl: 'https://replica.bnb.boba.network/',
+    providers: [{ alias: 'boba', rpcUrl: 'https://replica.bnb.boba.network/' }],
     explorer: {
       api: { url: 'https://blockexplorer.bnb.boba.network/api', key: { required: false } },
       browserUrl: 'https://blockexplorer.bnb.boba.network/',
@@ -169,7 +169,7 @@ export const CHAINS: Chain[] = [
     id: '288',
     symbol: 'BOBA',
     testnet: false,
-    providerUrl: 'https://lightning-replica.boba.network/',
+    providers: [{ alias: 'boba', rpcUrl: 'https://lightning-replica.boba.network/' }],
     explorer: {
       api: { url: 'https://api.bobascan.com/api', key: { required: true } },
       browserUrl: 'https://bobascan.com/',
@@ -182,7 +182,7 @@ export const CHAINS: Chain[] = [
     id: '97',
     symbol: 'testBNB',
     testnet: true,
-    providerUrl: 'https://data-seed-prebsc-1-s3.binance.org:8545/',
+    providers: [{ alias: 'binance', rpcUrl: 'https://data-seed-prebsc-1-s3.binance.org:8545/' }],
     explorer: {
       api: { url: 'https://api-testnet.bscscan.com/api', key: { required: true, hardhatEtherscanAlias: 'bscTestnet' } },
       browserUrl: 'https://testnet.bscscan.com/',
@@ -195,7 +195,7 @@ export const CHAINS: Chain[] = [
     id: '56',
     symbol: 'BNB',
     testnet: false,
-    providerUrl: 'https://rpc.ankr.com/bsc',
+    providers: [{ alias: 'ankr', rpcUrl: 'https://rpc.ankr.com/bsc' }],
     explorer: {
       api: { url: 'https://api.bscscan.com/api', key: { required: true, hardhatEtherscanAlias: 'bsc' } },
       browserUrl: 'https://bscscan.com/',
@@ -208,7 +208,7 @@ export const CHAINS: Chain[] = [
     id: '338',
     symbol: 'testCRO',
     testnet: true,
-    providerUrl: 'https://evm-t3.cronos.org',
+    providers: [{ alias: 'cronos', rpcUrl: 'https://evm-t3.cronos.org' }],
     explorer: {
       api: { url: 'https://cronos.org/explorer/testnet3/api', key: { required: false } },
       browserUrl: 'https://cronos.org/explorer/testnet3/',
@@ -221,7 +221,7 @@ export const CHAINS: Chain[] = [
     id: '5',
     symbol: 'testETH',
     testnet: true,
-    providerUrl: 'https://rpc.ankr.com/eth_goerli',
+    providers: [{ alias: 'ankr', rpcUrl: 'https://rpc.ankr.com/eth_goerli' }],
     explorer: {
       api: { url: 'https://api-goerli.etherscan.io/api', key: { required: true, hardhatEtherscanAlias: 'goerli' } },
       browserUrl: 'https://goerli.etherscan.io/',
@@ -234,7 +234,7 @@ export const CHAINS: Chain[] = [
     id: '11155111',
     symbol: 'testETH',
     testnet: true,
-    providerUrl: 'https://rpc-sepolia.rockx.com',
+    providers: [{ alias: 'rockx', rpcUrl: 'https://rpc-sepolia.rockx.com' }],
     explorer: {
       api: { url: 'https://api-sepolia.etherscan.io/api', key: { required: true, hardhatEtherscanAlias: 'sepolia' } },
       browserUrl: 'https://sepolia.etherscan.io/',
@@ -247,7 +247,7 @@ export const CHAINS: Chain[] = [
     id: '1',
     symbol: 'ETH',
     testnet: false,
-    providerUrl: 'https://eth.llamarpc.com',
+    providers: [{ alias: 'llamarpc', rpcUrl: 'https://eth.llamarpc.com' }],
     explorer: {
       api: { url: 'https://api.etherscan.io/api', key: { required: true, hardhatEtherscanAlias: 'mainnet' } },
       browserUrl: 'https://etherscan.io/',
@@ -260,7 +260,7 @@ export const CHAINS: Chain[] = [
     id: '4002',
     symbol: 'testFTM',
     testnet: true,
-    providerUrl: 'https://rpc.ankr.com/fantom_testnet',
+    providers: [{ alias: 'ankr', rpcUrl: 'https://rpc.ankr.com/fantom_testnet' }],
     explorer: {
       api: { url: 'https://api-testnet.ftmscan.com/api', key: { required: true, hardhatEtherscanAlias: 'ftmTestnet' } },
       browserUrl: 'https://testnet.ftmscan.com/',
@@ -273,7 +273,7 @@ export const CHAINS: Chain[] = [
     id: '250',
     symbol: 'FTM',
     testnet: false,
-    providerUrl: 'https://rpcapi.fantom.network/',
+    providers: [{ alias: 'fantom', rpcUrl: 'https://rpcapi.fantom.network/' }],
     explorer: {
       api: { url: 'https://api.ftmscan.com/api', key: { required: true, hardhatEtherscanAlias: 'opera' } },
       browserUrl: 'https://ftmscan.com/',
@@ -286,7 +286,7 @@ export const CHAINS: Chain[] = [
     id: '10200',
     symbol: 'testxDAI',
     testnet: true,
-    providerUrl: 'https://rpc.chiadochain.net',
+    providers: [{ alias: 'chiadochain', rpcUrl: 'https://rpc.chiadochain.net' }],
     explorer: {
       api: {
         url: 'https://gnosis-chiado.blockscout.com/api',
@@ -302,7 +302,7 @@ export const CHAINS: Chain[] = [
     id: '100',
     symbol: 'xDAI',
     testnet: false,
-    providerUrl: 'https://rpc.gnosischain.com',
+    providers: [{ alias: 'gnosischain', rpcUrl: 'https://rpc.gnosischain.com' }],
     explorer: {
       api: { url: 'https://api.gnosisscan.io/api', key: { required: true, hardhatEtherscanAlias: 'gnosis' } },
       browserUrl: 'https://gnosisscan.io/',
@@ -315,7 +315,7 @@ export const CHAINS: Chain[] = [
     id: '71401',
     symbol: 'testpCKB',
     testnet: true,
-    providerUrl: 'https://v1.testnet.godwoken.io/rpc',
+    providers: [{ alias: 'godwoken', rpcUrl: 'https://v1.testnet.godwoken.io/rpc' }],
     explorer: { browserUrl: 'https://v1.testnet.gwscan.com/' },
     blockTimeMs: 8127,
   },
@@ -325,7 +325,7 @@ export const CHAINS: Chain[] = [
     id: '71402',
     symbol: 'pCKB',
     testnet: false,
-    providerUrl: 'https://v1.mainnet.godwoken.io/rpc',
+    providers: [{ alias: 'godwoken', rpcUrl: 'https://v1.mainnet.godwoken.io/rpc' }],
     explorer: { browserUrl: 'https://v1.gwscan.com/' },
     blockTimeMs: 45041,
   },
@@ -335,7 +335,7 @@ export const CHAINS: Chain[] = [
     id: '2221',
     symbol: 'testKAVA',
     testnet: true,
-    providerUrl: 'https://evm.testnet.kava.io/',
+    providers: [{ alias: 'kava', rpcUrl: 'https://evm.testnet.kava.io/' }],
     explorer: {
       api: { url: 'https://testnet.kavascan.com/api', key: { required: false } },
       browserUrl: 'https://testnet.kavascan.com/',
@@ -348,7 +348,7 @@ export const CHAINS: Chain[] = [
     id: '2222',
     symbol: 'KAVA',
     testnet: false,
-    providerUrl: 'https://evm.kava.io/',
+    providers: [{ alias: 'kava', rpcUrl: 'https://evm.kava.io/' }],
     explorer: {
       api: { url: 'https://kavascan.com/api', key: { required: false } },
       browserUrl: 'https://kavascan.com/',
@@ -361,7 +361,7 @@ export const CHAINS: Chain[] = [
     id: '59140',
     symbol: 'testETH',
     testnet: true,
-    providerUrl: 'https://rpc.goerli.linea.build',
+    providers: [{ alias: 'linea', rpcUrl: 'https://rpc.goerli.linea.build' }],
     explorer: {
       api: { url: 'https://api-testnet.lineascan.build/api', key: { required: true } },
       browserUrl: 'https://goerli.lineascan.build/',
@@ -374,7 +374,7 @@ export const CHAINS: Chain[] = [
     id: '59144',
     symbol: 'ETH',
     testnet: false,
-    providerUrl: 'https://rpc.linea.build',
+    providers: [{ alias: 'linea', rpcUrl: 'https://rpc.linea.build' }],
     explorer: {
       api: { url: 'https://api.lineascan.build/api', key: { required: true } },
       browserUrl: 'https://lineascan.build/',
@@ -387,7 +387,7 @@ export const CHAINS: Chain[] = [
     id: '5001',
     symbol: 'MNT',
     testnet: true,
-    providerUrl: 'https://rpc.testnet.mantle.xyz',
+    providers: [{ alias: 'mantle', rpcUrl: 'https://rpc.testnet.mantle.xyz' }],
     explorer: {
       api: { url: 'https://explorer.testnet.mantle.xyz/api', key: { required: false } },
       browserUrl: 'https://explorer.testnet.mantle.xyz/',
@@ -400,7 +400,7 @@ export const CHAINS: Chain[] = [
     id: '5000',
     symbol: 'MNT',
     testnet: false,
-    providerUrl: 'https://rpc.mantle.xyz',
+    providers: [{ alias: 'mantle', rpcUrl: 'https://rpc.mantle.xyz' }],
     explorer: {
       api: { url: 'https://explorer.mantle.xyz/api', key: { required: false } },
       browserUrl: 'https://explorer.mantle.xyz/',
@@ -413,7 +413,7 @@ export const CHAINS: Chain[] = [
     id: '599',
     symbol: 'testMETIS',
     testnet: true,
-    providerUrl: 'https://goerli.gateway.metisdevops.link',
+    providers: [{ alias: 'metisdevops', rpcUrl: 'https://goerli.gateway.metisdevops.link' }],
     explorer: {
       api: { url: 'https://goerli.explorer.metisdevops.link/api', key: { required: false } },
       browserUrl: 'https://goerli.explorer.metisdevops.link/',
@@ -426,7 +426,7 @@ export const CHAINS: Chain[] = [
     id: '1088',
     symbol: 'METIS',
     testnet: false,
-    providerUrl: 'https://andromeda.metis.io/?owner=1088',
+    providers: [{ alias: 'metis', rpcUrl: 'https://andromeda.metis.io/?owner=1088' }],
     explorer: {
       api: { url: 'https://andromeda-explorer.metis.io/api', key: { required: false } },
       browserUrl: 'https://andromeda-explorer.metis.io/',
@@ -439,7 +439,7 @@ export const CHAINS: Chain[] = [
     id: '200101',
     symbol: 'testmilkADA',
     testnet: true,
-    providerUrl: 'https://rpc-devnet-cardano-evm.c1.milkomeda.com',
+    providers: [{ alias: 'milkomeda', rpcUrl: 'https://rpc-devnet-cardano-evm.c1.milkomeda.com' }],
     explorer: {
       api: { url: 'https://explorer-devnet-cardano-evm.c1.milkomeda.com/api', key: { required: false } },
       browserUrl: 'https://explorer-devnet-cardano-evm.c1.milkomeda.com/',
@@ -452,7 +452,7 @@ export const CHAINS: Chain[] = [
     id: '2001',
     symbol: 'milkADA',
     testnet: false,
-    providerUrl: 'https://rpc-mainnet-cardano-evm.c1.milkomeda.com',
+    providers: [{ alias: 'milkomeda', rpcUrl: 'https://rpc-mainnet-cardano-evm.c1.milkomeda.com' }],
     explorer: {
       api: { url: 'https://explorer-mainnet-cardano-evm.c1.milkomeda.com/api', key: { required: false } },
       browserUrl: 'https://explorer-mainnet-cardano-evm.c1.milkomeda.com/',
@@ -465,7 +465,7 @@ export const CHAINS: Chain[] = [
     id: '1287',
     symbol: 'testGLMR',
     testnet: true,
-    providerUrl: 'https://rpc.api.moonbase.moonbeam.network',
+    providers: [{ alias: 'moonbeam', rpcUrl: 'https://rpc.api.moonbase.moonbeam.network' }],
     explorer: {
       api: {
         url: 'https://api-moonbase.moonscan.io/api',
@@ -481,7 +481,7 @@ export const CHAINS: Chain[] = [
     id: '1284',
     symbol: 'GLMR',
     testnet: false,
-    providerUrl: 'https://rpc.api.moonbeam.network',
+    providers: [{ alias: 'moonbeam', rpcUrl: 'https://rpc.api.moonbeam.network' }],
     explorer: {
       api: { url: 'https://api-moonbeam.moonscan.io/api', key: { required: true, hardhatEtherscanAlias: 'moonbeam' } },
       browserUrl: 'https://moonscan.io/',
@@ -494,7 +494,7 @@ export const CHAINS: Chain[] = [
     id: '1285',
     symbol: 'MOVR',
     testnet: false,
-    providerUrl: 'https://rpc.api.moonriver.moonbeam.network',
+    providers: [{ alias: 'moonbeam', rpcUrl: 'https://rpc.api.moonriver.moonbeam.network' }],
     explorer: {
       api: {
         url: 'https://api-moonriver.moonscan.io/api',
@@ -510,7 +510,7 @@ export const CHAINS: Chain[] = [
     id: '420',
     symbol: 'testETH',
     testnet: true,
-    providerUrl: 'https://goerli.optimism.io',
+    providers: [{ alias: 'optimism', rpcUrl: 'https://goerli.optimism.io' }],
     explorer: {
       api: {
         url: 'https://api-goerli-optimism.etherscan.io/api',
@@ -526,7 +526,7 @@ export const CHAINS: Chain[] = [
     id: '10',
     symbol: 'ETH',
     testnet: false,
-    providerUrl: 'https://mainnet.optimism.io',
+    providers: [{ alias: 'optimism', rpcUrl: 'https://mainnet.optimism.io' }],
     explorer: {
       api: {
         url: 'https://api-optimistic.etherscan.io/api',
@@ -542,7 +542,7 @@ export const CHAINS: Chain[] = [
     id: '80001',
     symbol: 'testMATIC',
     testnet: true,
-    providerUrl: 'https://rpc.ankr.com/polygon_mumbai',
+    providers: [{ alias: 'ankr', rpcUrl: 'https://rpc.ankr.com/polygon_mumbai' }],
     explorer: {
       api: {
         url: 'https://api-testnet.polygonscan.com/api',
@@ -558,7 +558,7 @@ export const CHAINS: Chain[] = [
     id: '1442',
     symbol: 'testETH',
     testnet: true,
-    providerUrl: 'https://rpc.public.zkevm-test.net',
+    providers: [{ alias: 'zkevm-test', rpcUrl: 'https://rpc.public.zkevm-test.net' }],
     explorer: {
       api: { url: 'https://api-testnet-zkevm.polygonscan.com/api', key: { required: true } },
       browserUrl: 'https://testnet-zkevm.polygonscan.com/',
@@ -571,7 +571,7 @@ export const CHAINS: Chain[] = [
     id: '1101',
     symbol: 'ETH',
     testnet: false,
-    providerUrl: 'https://zkevm-rpc.com',
+    providers: [{ alias: 'zkevm-rpc', rpcUrl: 'https://zkevm-rpc.com' }],
     explorer: {
       api: { url: 'https://api-zkevm.polygonscan.com/api', key: { required: true } },
       browserUrl: 'https://zkevm.polygonscan.com/',
@@ -584,7 +584,7 @@ export const CHAINS: Chain[] = [
     id: '137',
     symbol: 'MATIC',
     testnet: false,
-    providerUrl: 'https://rpc.ankr.com/polygon',
+    providers: [{ alias: 'ankr', rpcUrl: 'https://rpc.ankr.com/polygon' }],
     explorer: {
       api: { url: 'https://api.polygonscan.com/api', key: { required: true, hardhatEtherscanAlias: 'polygon' } },
       browserUrl: 'https://polygonscan.com/',
@@ -597,7 +597,7 @@ export const CHAINS: Chain[] = [
     id: '31',
     symbol: 'testRBTC',
     testnet: true,
-    providerUrl: 'https://public-node.testnet.rsk.co',
+    providers: [{ alias: 'rsk', rpcUrl: 'https://public-node.testnet.rsk.co' }],
     explorer: { browserUrl: 'https://explorer.testnet.rsk.co/' },
     blockTimeMs: 26036,
   },
@@ -607,7 +607,7 @@ export const CHAINS: Chain[] = [
     id: '30',
     symbol: 'RBTC',
     testnet: false,
-    providerUrl: 'https://mainnet.sovryn.app/rpc',
+    providers: [{ alias: 'sovryn', rpcUrl: 'https://mainnet.sovryn.app/rpc' }],
     explorer: { browserUrl: 'https://explorer.rsk.co/' },
     blockTimeMs: 30946,
   },
@@ -617,7 +617,7 @@ export const CHAINS: Chain[] = [
     id: '534353',
     symbol: 'testETH',
     testnet: true,
-    providerUrl: 'https://alpha-rpc.scroll.io/l2',
+    providers: [{ alias: 'scroll', rpcUrl: 'https://alpha-rpc.scroll.io/l2' }],
     explorer: {
       api: { url: 'https://blockscout.scroll.io/api', key: { required: false } },
       browserUrl: 'https://blockscout.scroll.io/',
@@ -630,7 +630,7 @@ export const CHAINS: Chain[] = [
     id: '647',
     symbol: 'testSX',
     testnet: true,
-    providerUrl: 'https://rpc.toronto.sx.technology',
+    providers: [{ alias: 'sx', rpcUrl: 'https://rpc.toronto.sx.technology' }],
     explorer: {
       api: { url: 'https://explorer.toronto.sx.technology/api', key: { required: false } },
       browserUrl: 'https://explorer.toronto.sx.technology/',
@@ -643,7 +643,7 @@ export const CHAINS: Chain[] = [
     id: '416',
     symbol: 'SX',
     testnet: false,
-    providerUrl: 'https://rpc.sx.technology',
+    providers: [{ alias: 'sx', rpcUrl: 'https://rpc.sx.technology' }],
     explorer: {
       api: { url: 'https://explorer.sx.technology/api', key: { required: false } },
       browserUrl: 'https://explorer.sx.technology/',
@@ -656,7 +656,7 @@ export const CHAINS: Chain[] = [
     id: '280',
     symbol: 'testETH',
     testnet: true,
-    providerUrl: 'https://testnet.era.zksync.dev',
+    providers: [{ alias: 'zksync', rpcUrl: 'https://testnet.era.zksync.dev' }],
     explorer: { browserUrl: 'https://goerli.explorer.zksync.io/' },
     blockTimeMs: 1069,
   },
@@ -666,7 +666,7 @@ export const CHAINS: Chain[] = [
     id: '324',
     symbol: 'ETH',
     testnet: false,
-    providerUrl: 'https://mainnet.era.zksync.io',
+    providers: [{ alias: 'zksync', rpcUrl: 'https://mainnet.era.zksync.io' }],
     explorer: { browserUrl: 'https://explorer.zksync.io/' },
     blockTimeMs: 1020,
   },

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -88,7 +88,7 @@ export const CHAINS: Chain[] = [
     id: '43113',
     symbol: 'testAVAX',
     testnet: true,
-    providers: [{ alias: 'avalanche', rpcUrl: 'https://api.avax-test.network/ext/bc/C/rpc' }],
+    providers: [{ alias: 'avax-test', rpcUrl: 'https://api.avax-test.network/ext/bc/C/rpc' }],
     explorer: {
       api: {
         url: 'https://api-testnet.snowtrace.io/api',
@@ -104,7 +104,7 @@ export const CHAINS: Chain[] = [
     id: '43114',
     symbol: 'AVAX',
     testnet: false,
-    providers: [{ alias: 'avalanche', rpcUrl: 'https://api.avax.network/ext/bc/C/rpc' }],
+    providers: [{ alias: 'avax', rpcUrl: 'https://api.avax.network/ext/bc/C/rpc' }],
     explorer: {
       api: { url: 'https://api.snowtrace.io/api', key: { required: true, hardhatEtherscanAlias: 'avalanche' } },
       browserUrl: 'https://snowtrace.io/',

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -14,7 +14,7 @@ export const CHAINS: Chain[] = [
     id: '421613',
     symbol: 'testETH',
     testnet: true,
-    providers: [{ alias: 'arbitrum', rpcUrl: 'https://goerli-rollup.arbitrum.io/rpc' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://goerli-rollup.arbitrum.io/rpc' }],
     explorer: {
       api: {
         url: 'https://api-goerli.arbiscan.io/api',
@@ -30,7 +30,7 @@ export const CHAINS: Chain[] = [
     id: '42170',
     symbol: 'ETH',
     testnet: false,
-    providers: [{ alias: 'arbitrum', rpcUrl: 'https://nova.arbitrum.io/rpc' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://nova.arbitrum.io/rpc' }],
     explorer: {
       api: { url: 'https://api-nova.arbiscan.io/api', key: { required: true } },
       browserUrl: 'https://nova.arbiscan.io/',
@@ -43,7 +43,7 @@ export const CHAINS: Chain[] = [
     id: '42161',
     symbol: 'ETH',
     testnet: false,
-    providers: [{ alias: 'arbitrum', rpcUrl: 'https://arb1.arbitrum.io/rpc' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://arb1.arbitrum.io/rpc' }],
     explorer: {
       api: { url: 'https://api.arbiscan.io/api', key: { required: true, hardhatEtherscanAlias: 'arbitrumOne' } },
       browserUrl: 'https://arbiscan.io/',
@@ -56,7 +56,7 @@ export const CHAINS: Chain[] = [
     id: '1313161555',
     symbol: 'testETH',
     testnet: true,
-    providers: [{ alias: 'aurora', rpcUrl: 'https://testnet.aurora.dev/' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://testnet.aurora.dev/' }],
     explorer: {
       api: {
         url: 'https://explorer.testnet.aurora.dev/api',
@@ -72,7 +72,7 @@ export const CHAINS: Chain[] = [
     id: '1313161554',
     symbol: 'ETH',
     testnet: false,
-    providers: [{ alias: 'aurora', rpcUrl: 'https://mainnet.aurora.dev/' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://mainnet.aurora.dev/' }],
     explorer: {
       api: {
         url: 'https://explorer.mainnet.aurora.dev/api',
@@ -88,7 +88,7 @@ export const CHAINS: Chain[] = [
     id: '43113',
     symbol: 'testAVAX',
     testnet: true,
-    providers: [{ alias: 'avax-test', rpcUrl: 'https://api.avax-test.network/ext/bc/C/rpc' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://api.avax-test.network/ext/bc/C/rpc' }],
     explorer: {
       api: {
         url: 'https://api-testnet.snowtrace.io/api',
@@ -104,7 +104,7 @@ export const CHAINS: Chain[] = [
     id: '43114',
     symbol: 'AVAX',
     testnet: false,
-    providers: [{ alias: 'avax', rpcUrl: 'https://api.avax.network/ext/bc/C/rpc' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://api.avax.network/ext/bc/C/rpc' }],
     explorer: {
       api: { url: 'https://api.snowtrace.io/api', key: { required: true, hardhatEtherscanAlias: 'avalanche' } },
       browserUrl: 'https://snowtrace.io/',
@@ -117,7 +117,7 @@ export const CHAINS: Chain[] = [
     id: '84531',
     symbol: 'testETH',
     testnet: true,
-    providers: [{ alias: 'base', rpcUrl: 'https://goerli.base.org' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://goerli.base.org' }],
     explorer: {
       api: { url: 'https://api-goerli.basescan.org/api', key: { required: false } },
       browserUrl: 'https://goerli.basescan.org/',
@@ -130,7 +130,7 @@ export const CHAINS: Chain[] = [
     id: '8453',
     symbol: 'ETH',
     testnet: false,
-    providers: [{ alias: 'base', rpcUrl: 'https://mainnet.base.org' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://mainnet.base.org' }],
     explorer: {
       api: { url: 'https://api.basescan.org/api', key: { required: true } },
       browserUrl: 'https://basescan.org/',
@@ -143,7 +143,7 @@ export const CHAINS: Chain[] = [
     id: '43288',
     symbol: 'BOBA',
     testnet: false,
-    providers: [{ alias: 'boba', rpcUrl: 'https://replica.avax.boba.network/' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://replica.avax.boba.network/' }],
     explorer: {
       api: { url: 'https://blockexplorer.avax.boba.network/api', key: { required: false } },
       browserUrl: 'https://blockexplorer.avax.boba.network/',
@@ -156,7 +156,7 @@ export const CHAINS: Chain[] = [
     id: '56288',
     symbol: 'BOBA',
     testnet: false,
-    providers: [{ alias: 'boba', rpcUrl: 'https://replica.bnb.boba.network/' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://replica.bnb.boba.network/' }],
     explorer: {
       api: { url: 'https://blockexplorer.bnb.boba.network/api', key: { required: false } },
       browserUrl: 'https://blockexplorer.bnb.boba.network/',
@@ -169,7 +169,7 @@ export const CHAINS: Chain[] = [
     id: '288',
     symbol: 'BOBA',
     testnet: false,
-    providers: [{ alias: 'boba', rpcUrl: 'https://lightning-replica.boba.network/' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://lightning-replica.boba.network/' }],
     explorer: {
       api: { url: 'https://api.bobascan.com/api', key: { required: true } },
       browserUrl: 'https://bobascan.com/',
@@ -182,7 +182,7 @@ export const CHAINS: Chain[] = [
     id: '97',
     symbol: 'testBNB',
     testnet: true,
-    providers: [{ alias: 'binance', rpcUrl: 'https://data-seed-prebsc-1-s3.binance.org:8545/' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://data-seed-prebsc-1-s3.binance.org:8545/' }],
     explorer: {
       api: { url: 'https://api-testnet.bscscan.com/api', key: { required: true, hardhatEtherscanAlias: 'bscTestnet' } },
       browserUrl: 'https://testnet.bscscan.com/',
@@ -195,7 +195,7 @@ export const CHAINS: Chain[] = [
     id: '56',
     symbol: 'BNB',
     testnet: false,
-    providers: [{ alias: 'ankr', rpcUrl: 'https://rpc.ankr.com/bsc' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.ankr.com/bsc' }],
     explorer: {
       api: { url: 'https://api.bscscan.com/api', key: { required: true, hardhatEtherscanAlias: 'bsc' } },
       browserUrl: 'https://bscscan.com/',
@@ -208,7 +208,7 @@ export const CHAINS: Chain[] = [
     id: '338',
     symbol: 'testCRO',
     testnet: true,
-    providers: [{ alias: 'cronos', rpcUrl: 'https://evm-t3.cronos.org' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://evm-t3.cronos.org' }],
     explorer: {
       api: { url: 'https://cronos.org/explorer/testnet3/api', key: { required: false } },
       browserUrl: 'https://cronos.org/explorer/testnet3/',
@@ -221,7 +221,7 @@ export const CHAINS: Chain[] = [
     id: '5',
     symbol: 'testETH',
     testnet: true,
-    providers: [{ alias: 'ankr', rpcUrl: 'https://rpc.ankr.com/eth_goerli' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.ankr.com/eth_goerli' }],
     explorer: {
       api: { url: 'https://api-goerli.etherscan.io/api', key: { required: true, hardhatEtherscanAlias: 'goerli' } },
       browserUrl: 'https://goerli.etherscan.io/',
@@ -234,7 +234,7 @@ export const CHAINS: Chain[] = [
     id: '11155111',
     symbol: 'testETH',
     testnet: true,
-    providers: [{ alias: 'rockx', rpcUrl: 'https://rpc-sepolia.rockx.com' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc-sepolia.rockx.com' }],
     explorer: {
       api: { url: 'https://api-sepolia.etherscan.io/api', key: { required: true, hardhatEtherscanAlias: 'sepolia' } },
       browserUrl: 'https://sepolia.etherscan.io/',
@@ -247,7 +247,7 @@ export const CHAINS: Chain[] = [
     id: '1',
     symbol: 'ETH',
     testnet: false,
-    providers: [{ alias: 'llamarpc', rpcUrl: 'https://eth.llamarpc.com' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://eth.llamarpc.com' }],
     explorer: {
       api: { url: 'https://api.etherscan.io/api', key: { required: true, hardhatEtherscanAlias: 'mainnet' } },
       browserUrl: 'https://etherscan.io/',
@@ -260,7 +260,7 @@ export const CHAINS: Chain[] = [
     id: '4002',
     symbol: 'testFTM',
     testnet: true,
-    providers: [{ alias: 'ankr', rpcUrl: 'https://rpc.ankr.com/fantom_testnet' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.ankr.com/fantom_testnet' }],
     explorer: {
       api: { url: 'https://api-testnet.ftmscan.com/api', key: { required: true, hardhatEtherscanAlias: 'ftmTestnet' } },
       browserUrl: 'https://testnet.ftmscan.com/',
@@ -273,7 +273,7 @@ export const CHAINS: Chain[] = [
     id: '250',
     symbol: 'FTM',
     testnet: false,
-    providers: [{ alias: 'fantom', rpcUrl: 'https://rpcapi.fantom.network/' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpcapi.fantom.network/' }],
     explorer: {
       api: { url: 'https://api.ftmscan.com/api', key: { required: true, hardhatEtherscanAlias: 'opera' } },
       browserUrl: 'https://ftmscan.com/',
@@ -286,7 +286,7 @@ export const CHAINS: Chain[] = [
     id: '10200',
     symbol: 'testxDAI',
     testnet: true,
-    providers: [{ alias: 'chiadochain', rpcUrl: 'https://rpc.chiadochain.net' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.chiadochain.net' }],
     explorer: {
       api: {
         url: 'https://gnosis-chiado.blockscout.com/api',
@@ -302,7 +302,7 @@ export const CHAINS: Chain[] = [
     id: '100',
     symbol: 'xDAI',
     testnet: false,
-    providers: [{ alias: 'gnosischain', rpcUrl: 'https://rpc.gnosischain.com' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.gnosischain.com' }],
     explorer: {
       api: { url: 'https://api.gnosisscan.io/api', key: { required: true, hardhatEtherscanAlias: 'gnosis' } },
       browserUrl: 'https://gnosisscan.io/',
@@ -315,7 +315,7 @@ export const CHAINS: Chain[] = [
     id: '71401',
     symbol: 'testpCKB',
     testnet: true,
-    providers: [{ alias: 'godwoken', rpcUrl: 'https://v1.testnet.godwoken.io/rpc' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://v1.testnet.godwoken.io/rpc' }],
     explorer: { browserUrl: 'https://v1.testnet.gwscan.com/' },
     blockTimeMs: 8127,
   },
@@ -325,7 +325,7 @@ export const CHAINS: Chain[] = [
     id: '71402',
     symbol: 'pCKB',
     testnet: false,
-    providers: [{ alias: 'godwoken', rpcUrl: 'https://v1.mainnet.godwoken.io/rpc' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://v1.mainnet.godwoken.io/rpc' }],
     explorer: { browserUrl: 'https://v1.gwscan.com/' },
     blockTimeMs: 45041,
   },
@@ -335,7 +335,7 @@ export const CHAINS: Chain[] = [
     id: '2221',
     symbol: 'testKAVA',
     testnet: true,
-    providers: [{ alias: 'kava', rpcUrl: 'https://evm.testnet.kava.io/' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://evm.testnet.kava.io/' }],
     explorer: {
       api: { url: 'https://testnet.kavascan.com/api', key: { required: false } },
       browserUrl: 'https://testnet.kavascan.com/',
@@ -348,7 +348,7 @@ export const CHAINS: Chain[] = [
     id: '2222',
     symbol: 'KAVA',
     testnet: false,
-    providers: [{ alias: 'kava', rpcUrl: 'https://evm.kava.io/' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://evm.kava.io/' }],
     explorer: {
       api: { url: 'https://kavascan.com/api', key: { required: false } },
       browserUrl: 'https://kavascan.com/',
@@ -361,7 +361,7 @@ export const CHAINS: Chain[] = [
     id: '59140',
     symbol: 'testETH',
     testnet: true,
-    providers: [{ alias: 'linea', rpcUrl: 'https://rpc.goerli.linea.build' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.goerli.linea.build' }],
     explorer: {
       api: { url: 'https://api-testnet.lineascan.build/api', key: { required: true } },
       browserUrl: 'https://goerli.lineascan.build/',
@@ -374,7 +374,7 @@ export const CHAINS: Chain[] = [
     id: '59144',
     symbol: 'ETH',
     testnet: false,
-    providers: [{ alias: 'linea', rpcUrl: 'https://rpc.linea.build' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.linea.build' }],
     explorer: {
       api: { url: 'https://api.lineascan.build/api', key: { required: true } },
       browserUrl: 'https://lineascan.build/',
@@ -387,7 +387,7 @@ export const CHAINS: Chain[] = [
     id: '5001',
     symbol: 'MNT',
     testnet: true,
-    providers: [{ alias: 'mantle', rpcUrl: 'https://rpc.testnet.mantle.xyz' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.testnet.mantle.xyz' }],
     explorer: {
       api: { url: 'https://explorer.testnet.mantle.xyz/api', key: { required: false } },
       browserUrl: 'https://explorer.testnet.mantle.xyz/',
@@ -400,7 +400,7 @@ export const CHAINS: Chain[] = [
     id: '5000',
     symbol: 'MNT',
     testnet: false,
-    providers: [{ alias: 'mantle', rpcUrl: 'https://rpc.mantle.xyz' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.mantle.xyz' }],
     explorer: {
       api: { url: 'https://explorer.mantle.xyz/api', key: { required: false } },
       browserUrl: 'https://explorer.mantle.xyz/',
@@ -413,7 +413,7 @@ export const CHAINS: Chain[] = [
     id: '599',
     symbol: 'testMETIS',
     testnet: true,
-    providers: [{ alias: 'metisdevops', rpcUrl: 'https://goerli.gateway.metisdevops.link' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://goerli.gateway.metisdevops.link' }],
     explorer: {
       api: { url: 'https://goerli.explorer.metisdevops.link/api', key: { required: false } },
       browserUrl: 'https://goerli.explorer.metisdevops.link/',
@@ -426,7 +426,7 @@ export const CHAINS: Chain[] = [
     id: '1088',
     symbol: 'METIS',
     testnet: false,
-    providers: [{ alias: 'metis', rpcUrl: 'https://andromeda.metis.io/?owner=1088' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://andromeda.metis.io/?owner=1088' }],
     explorer: {
       api: { url: 'https://andromeda-explorer.metis.io/api', key: { required: false } },
       browserUrl: 'https://andromeda-explorer.metis.io/',
@@ -439,7 +439,7 @@ export const CHAINS: Chain[] = [
     id: '200101',
     symbol: 'testmilkADA',
     testnet: true,
-    providers: [{ alias: 'milkomeda', rpcUrl: 'https://rpc-devnet-cardano-evm.c1.milkomeda.com' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc-devnet-cardano-evm.c1.milkomeda.com' }],
     explorer: {
       api: { url: 'https://explorer-devnet-cardano-evm.c1.milkomeda.com/api', key: { required: false } },
       browserUrl: 'https://explorer-devnet-cardano-evm.c1.milkomeda.com/',
@@ -452,7 +452,7 @@ export const CHAINS: Chain[] = [
     id: '2001',
     symbol: 'milkADA',
     testnet: false,
-    providers: [{ alias: 'milkomeda', rpcUrl: 'https://rpc-mainnet-cardano-evm.c1.milkomeda.com' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc-mainnet-cardano-evm.c1.milkomeda.com' }],
     explorer: {
       api: { url: 'https://explorer-mainnet-cardano-evm.c1.milkomeda.com/api', key: { required: false } },
       browserUrl: 'https://explorer-mainnet-cardano-evm.c1.milkomeda.com/',
@@ -465,7 +465,7 @@ export const CHAINS: Chain[] = [
     id: '1287',
     symbol: 'testGLMR',
     testnet: true,
-    providers: [{ alias: 'moonbeam', rpcUrl: 'https://rpc.api.moonbase.moonbeam.network' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.api.moonbase.moonbeam.network' }],
     explorer: {
       api: {
         url: 'https://api-moonbase.moonscan.io/api',
@@ -481,7 +481,7 @@ export const CHAINS: Chain[] = [
     id: '1284',
     symbol: 'GLMR',
     testnet: false,
-    providers: [{ alias: 'moonbeam', rpcUrl: 'https://rpc.api.moonbeam.network' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.api.moonbeam.network' }],
     explorer: {
       api: { url: 'https://api-moonbeam.moonscan.io/api', key: { required: true, hardhatEtherscanAlias: 'moonbeam' } },
       browserUrl: 'https://moonscan.io/',
@@ -494,7 +494,7 @@ export const CHAINS: Chain[] = [
     id: '1285',
     symbol: 'MOVR',
     testnet: false,
-    providers: [{ alias: 'moonbeam', rpcUrl: 'https://rpc.api.moonriver.moonbeam.network' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.api.moonriver.moonbeam.network' }],
     explorer: {
       api: {
         url: 'https://api-moonriver.moonscan.io/api',
@@ -510,7 +510,7 @@ export const CHAINS: Chain[] = [
     id: '420',
     symbol: 'testETH',
     testnet: true,
-    providers: [{ alias: 'optimism', rpcUrl: 'https://goerli.optimism.io' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://goerli.optimism.io' }],
     explorer: {
       api: {
         url: 'https://api-goerli-optimism.etherscan.io/api',
@@ -526,7 +526,7 @@ export const CHAINS: Chain[] = [
     id: '10',
     symbol: 'ETH',
     testnet: false,
-    providers: [{ alias: 'optimism', rpcUrl: 'https://mainnet.optimism.io' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://mainnet.optimism.io' }],
     explorer: {
       api: {
         url: 'https://api-optimistic.etherscan.io/api',
@@ -542,7 +542,7 @@ export const CHAINS: Chain[] = [
     id: '80001',
     symbol: 'testMATIC',
     testnet: true,
-    providers: [{ alias: 'ankr', rpcUrl: 'https://rpc.ankr.com/polygon_mumbai' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.ankr.com/polygon_mumbai' }],
     explorer: {
       api: {
         url: 'https://api-testnet.polygonscan.com/api',
@@ -558,7 +558,7 @@ export const CHAINS: Chain[] = [
     id: '1442',
     symbol: 'testETH',
     testnet: true,
-    providers: [{ alias: 'zkevm-test', rpcUrl: 'https://rpc.public.zkevm-test.net' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.public.zkevm-test.net' }],
     explorer: {
       api: { url: 'https://api-testnet-zkevm.polygonscan.com/api', key: { required: true } },
       browserUrl: 'https://testnet-zkevm.polygonscan.com/',
@@ -571,7 +571,7 @@ export const CHAINS: Chain[] = [
     id: '1101',
     symbol: 'ETH',
     testnet: false,
-    providers: [{ alias: 'zkevm-rpc', rpcUrl: 'https://zkevm-rpc.com' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://zkevm-rpc.com' }],
     explorer: {
       api: { url: 'https://api-zkevm.polygonscan.com/api', key: { required: true } },
       browserUrl: 'https://zkevm.polygonscan.com/',
@@ -584,7 +584,7 @@ export const CHAINS: Chain[] = [
     id: '137',
     symbol: 'MATIC',
     testnet: false,
-    providers: [{ alias: 'ankr', rpcUrl: 'https://rpc.ankr.com/polygon' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.ankr.com/polygon' }],
     explorer: {
       api: { url: 'https://api.polygonscan.com/api', key: { required: true, hardhatEtherscanAlias: 'polygon' } },
       browserUrl: 'https://polygonscan.com/',
@@ -597,7 +597,7 @@ export const CHAINS: Chain[] = [
     id: '31',
     symbol: 'testRBTC',
     testnet: true,
-    providers: [{ alias: 'rsk', rpcUrl: 'https://public-node.testnet.rsk.co' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://public-node.testnet.rsk.co' }],
     explorer: { browserUrl: 'https://explorer.testnet.rsk.co/' },
     blockTimeMs: 26036,
   },
@@ -607,7 +607,7 @@ export const CHAINS: Chain[] = [
     id: '30',
     symbol: 'RBTC',
     testnet: false,
-    providers: [{ alias: 'sovryn', rpcUrl: 'https://mainnet.sovryn.app/rpc' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://mainnet.sovryn.app/rpc' }],
     explorer: { browserUrl: 'https://explorer.rsk.co/' },
     blockTimeMs: 30946,
   },
@@ -617,7 +617,7 @@ export const CHAINS: Chain[] = [
     id: '534353',
     symbol: 'testETH',
     testnet: true,
-    providers: [{ alias: 'scroll', rpcUrl: 'https://alpha-rpc.scroll.io/l2' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://alpha-rpc.scroll.io/l2' }],
     explorer: {
       api: { url: 'https://blockscout.scroll.io/api', key: { required: false } },
       browserUrl: 'https://blockscout.scroll.io/',
@@ -630,7 +630,7 @@ export const CHAINS: Chain[] = [
     id: '647',
     symbol: 'testSX',
     testnet: true,
-    providers: [{ alias: 'sx', rpcUrl: 'https://rpc.toronto.sx.technology' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.toronto.sx.technology' }],
     explorer: {
       api: { url: 'https://explorer.toronto.sx.technology/api', key: { required: false } },
       browserUrl: 'https://explorer.toronto.sx.technology/',
@@ -643,7 +643,7 @@ export const CHAINS: Chain[] = [
     id: '416',
     symbol: 'SX',
     testnet: false,
-    providers: [{ alias: 'sx', rpcUrl: 'https://rpc.sx.technology' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.sx.technology' }],
     explorer: {
       api: { url: 'https://explorer.sx.technology/api', key: { required: false } },
       browserUrl: 'https://explorer.sx.technology/',
@@ -656,7 +656,7 @@ export const CHAINS: Chain[] = [
     id: '280',
     symbol: 'testETH',
     testnet: true,
-    providers: [{ alias: 'zksync', rpcUrl: 'https://testnet.era.zksync.dev' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://testnet.era.zksync.dev' }],
     explorer: { browserUrl: 'https://goerli.explorer.zksync.io/' },
     blockTimeMs: 1069,
   },
@@ -666,7 +666,7 @@ export const CHAINS: Chain[] = [
     id: '324',
     symbol: 'ETH',
     testnet: false,
-    providers: [{ alias: 'zksync', rpcUrl: 'https://mainnet.era.zksync.io' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://mainnet.era.zksync.io' }],
     explorer: { browserUrl: 'https://explorer.zksync.io/' },
     blockTimeMs: 1020,
   },

--- a/src/hardhat-config.test.ts
+++ b/src/hardhat-config.test.ts
@@ -195,10 +195,11 @@ describe(networks.name, () => {
     expect(Object.keys(result).length).toEqual(CHAINS.length);
 
     CHAINS.forEach((chain) => {
+      const firstProviderRpcUrl = chain.providers.find((p) => p.rpcUrl)?.rpcUrl;
       expect(result[chain.alias]).toEqual({
         accounts: { mnemonic: '' },
         chainId: Number(chain.id),
-        url: chain.providerUrl,
+        url: firstProviderRpcUrl,
       });
     });
   });
@@ -207,10 +208,11 @@ describe(networks.name, () => {
     process.env.MNEMONIC = 'test test test test test test test test test test test junk';
     const result = networks();
     CHAINS.forEach((chain) => {
+      const firstProviderRpcUrl = chain.providers.find((p) => p.rpcUrl)?.rpcUrl;
       expect(result[chain.alias]).toEqual({
         accounts: { mnemonic: 'test test test test test test test test test test test junk' },
         chainId: Number(chain.id),
-        url: chain.providerUrl,
+        url: firstProviderRpcUrl,
       });
     });
   });

--- a/src/hardhat-config.test.ts
+++ b/src/hardhat-config.test.ts
@@ -195,11 +195,11 @@ describe(networks.name, () => {
     expect(Object.keys(result).length).toEqual(CHAINS.length);
 
     CHAINS.forEach((chain) => {
-      const firstProviderRpcUrl = chain.providers.find((p) => p.rpcUrl)?.rpcUrl;
+      const defaultProvider = chain.providers.find((p) => p.alias === 'default')!;
       expect(result[chain.alias]).toEqual({
         accounts: { mnemonic: '' },
         chainId: Number(chain.id),
-        url: firstProviderRpcUrl,
+        url: defaultProvider.rpcUrl,
       });
     });
   });
@@ -208,11 +208,11 @@ describe(networks.name, () => {
     process.env.MNEMONIC = 'test test test test test test test test test test test junk';
     const result = networks();
     CHAINS.forEach((chain) => {
-      const firstProviderRpcUrl = chain.providers.find((p) => p.rpcUrl)?.rpcUrl;
+      const defaultProvider = chain.providers.find((p) => p.alias === 'default')!;
       expect(result[chain.alias]).toEqual({
         accounts: { mnemonic: 'test test test test test test test test test test test junk' },
         chainId: Number(chain.id),
-        url: firstProviderRpcUrl,
+        url: defaultProvider.rpcUrl,
       });
     });
   });

--- a/src/hardhat-config.ts
+++ b/src/hardhat-config.ts
@@ -65,10 +65,12 @@ export function networks(): HardhatNetworksConfig {
   }
 
   return CHAINS.reduce((networks, chain) => {
+    const firstProviderRpcUrl = chain.providers.find((p) => p.rpcUrl)?.rpcUrl;
+
     networks[chain.alias] = {
       accounts: { mnemonic: process.env.MNEMONIC || '' },
       chainId: Number(chain.id),
-      url: process.env[networkHttpRpcUrlName(chain)] || chain.providerUrl,
+      url: process.env[networkHttpRpcUrlName(chain)] || firstProviderRpcUrl || '',
     };
     return networks;
   }, {} as HardhatNetworksConfig);

--- a/src/hardhat-config.ts
+++ b/src/hardhat-config.ts
@@ -65,12 +65,12 @@ export function networks(): HardhatNetworksConfig {
   }
 
   return CHAINS.reduce((networks, chain) => {
-    const firstProviderRpcUrl = chain.providers.find((p) => p.rpcUrl)?.rpcUrl;
+    const defaultProvider = chain.providers.find((p) => p.alias === 'default');
 
     networks[chain.alias] = {
       accounts: { mnemonic: process.env.MNEMONIC || '' },
       chainId: Number(chain.id),
-      url: process.env[networkHttpRpcUrlName(chain)] || firstProviderRpcUrl || '',
+      url: process.env[networkHttpRpcUrlName(chain)] || defaultProvider!.rpcUrl!,
     };
     return networks;
   }, {} as HardhatNetworksConfig);

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,15 +15,17 @@ export const chainExplorerSchema = z.object({
   browserUrl: z.string().url(),
 });
 
-export const chainProviderSchema = z.object({
-  alias: z.string(),
-  homepageUrl: z.string().url().optional(),
-  rpcUrl: z.string().url().optional(),
-}).refine(
-  // Either rpcUrl or homepageUrl must be present
-  (provider) => provider.rpcUrl || provider.homepageUrl,
-  { message: 'rpcUrl or homepageUrl is required' } 
-);
+export const chainProviderSchema = z
+  .object({
+    alias: z.string(),
+    homepageUrl: z.string().url().optional(),
+    rpcUrl: z.string().url().optional(),
+  })
+  .refine(
+    // Either rpcUrl or homepageUrl must be present
+    (provider) => provider.rpcUrl || provider.homepageUrl,
+    { message: 'rpcUrl or homepageUrl is required' }
+  );
 
 export const chainSchema = z.object({
   alias: z.string(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,11 @@ export const chainProviderSchema = z.object({
   alias: z.string(),
   homepageUrl: z.string().url().optional(),
   rpcUrl: z.string().url().optional(),
-});
+}).refine(
+  // Either rpcUrl or homepageUrl must be present
+  (provider) => provider.rpcUrl || provider.homepageUrl,
+  { message: 'rpcUrl or homepageUrl is required' } 
+);
 
 export const chainSchema = z.object({
   alias: z.string(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,15 @@ export const chainProvidersSchema = z.array(chainProviderSchema).superRefine((pr
       message: "cannot contain duplicate 'alias' values",
     });
   }
+
+  providers.forEach((p) => {
+    if ((p.alias === 'default' || p.alias === 'public') && !p.rpcUrl) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "providers with alias 'default' or 'public' must also have an 'rpcUrl'",
+      });
+    }
+  });
 });
 
 export const chainSchema = z.object({

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { hasUniqueObjects } from './utils/arrays';
+import { hasUniqueEntries } from './utils/arrays';
 
 export const chainExplorerAPIKeySchema = z.object({
   required: z.boolean(),
@@ -36,7 +36,7 @@ export const chainProvidersSchema = z.array(chainProviderSchema).superRefine((pr
     });
   }
 
-  if (!hasUniqueObjects(providers, 'alias')) {
+  if (!hasUniqueEntries(providers, 'alias')) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       message: "cannot contain duplicate 'alias' values",

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,12 @@ export const chainExplorerSchema = z.object({
   browserUrl: z.string().url(),
 });
 
+export const chainProviderSchema = z.object({
+  alias: z.string(),
+  homepageUrl: z.string().url().optional(),
+  rpcUrl: z.string().url().optional(),
+});
+
 export const chainSchema = z.object({
   alias: z.string(),
   name: z.string(),
@@ -22,7 +28,7 @@ export const chainSchema = z.object({
   // It can be adjusted if we want to support chains that don't use numbers.
   // See: https://github.com/api3dao/chains/pull/1#discussion_r1161102392
   id: z.string().regex(/^\d+$/),
-  providerUrl: z.string().url(),
+  providers: z.array(chainProviderSchema),
   symbol: z.string(),
   testnet: z.boolean(),
   explorer: chainExplorerSchema,

--- a/src/utils/arrays.test.ts
+++ b/src/utils/arrays.test.ts
@@ -1,0 +1,57 @@
+import { hasUniqueObjects } from './arrays';
+
+describe(hasUniqueObjects.name, () => {
+  test('returns true for an empty array', () => {
+    const items: any[] = [];
+    expect(hasUniqueObjects(items, 'id')).toBe(true);
+  });
+
+  test('returns false for duplicates based on specified field', () => {
+    const items = [
+      { id: 1, name: 'A' },
+      { id: 2, name: 'B' },
+      { id: 1, name: 'C' },
+    ];
+    expect(hasUniqueObjects(items, 'id')).toBe(false);
+  });
+
+  test('returns true if no duplicates based on specified field', () => {
+    const items = [
+      { id: 1, name: 'A' },
+      { id: 2, name: 'B' },
+      { id: 3, name: 'C' },
+    ];
+    expect(hasUniqueObjects(items, 'id')).toBe(true);
+  });
+
+  test('returns true for an array with a single element', () => {
+    const items = [{ id: 1, name: 'A' }];
+    expect(hasUniqueObjects(items, 'id')).toBe(true);
+  });
+
+  test('throws an error for a non-existing field', () => {
+    const items = [
+      { id: 1, name: 'A' },
+      { id: 2, name: 'B' },
+    ];
+    expect(() => hasUniqueObjects(items, 'nonExistingField')).toThrow('unknown field:nonExistingField on array item');
+  });
+
+  test('returns false for duplicates in non-primary field', () => {
+    const items = [
+      { id: 1, name: 'A' },
+      { id: 2, name: 'A' },
+    ];
+    expect(hasUniqueObjects(items, 'name')).toBe(false);
+  });
+
+  test('throws an error given an array of primitives', () => {
+    const items = [1, 2, 3, 1];
+    expect(() => hasUniqueObjects(items as any, 'id')).toThrow('unknown field:id on array item');
+  });
+
+  test('throws an error given an array of different object structures', () => {
+    const items = [{ id: 1, name: 'A' }, { id: 2, name: 'B' }, 3];
+    expect(() => hasUniqueObjects(items, 'id')).toThrow('unknown field:id on array item');
+  });
+});

--- a/src/utils/arrays.test.ts
+++ b/src/utils/arrays.test.ts
@@ -1,9 +1,9 @@
-import { hasUniqueObjects } from './arrays';
+import { hasUniqueEntries } from './arrays';
 
-describe(hasUniqueObjects.name, () => {
+describe(hasUniqueEntries.name, () => {
   test('returns true for an empty array', () => {
     const items: any[] = [];
-    expect(hasUniqueObjects(items, 'id')).toBe(true);
+    expect(hasUniqueEntries(items, 'id')).toBe(true);
   });
 
   test('returns false for duplicates based on specified field', () => {
@@ -12,7 +12,7 @@ describe(hasUniqueObjects.name, () => {
       { id: 2, name: 'B' },
       { id: 1, name: 'C' },
     ];
-    expect(hasUniqueObjects(items, 'id')).toBe(false);
+    expect(hasUniqueEntries(items, 'id')).toBe(false);
   });
 
   test('returns true if no duplicates based on specified field', () => {
@@ -21,12 +21,12 @@ describe(hasUniqueObjects.name, () => {
       { id: 2, name: 'B' },
       { id: 3, name: 'C' },
     ];
-    expect(hasUniqueObjects(items, 'id')).toBe(true);
+    expect(hasUniqueEntries(items, 'id')).toBe(true);
   });
 
   test('returns true for an array with a single element', () => {
     const items = [{ id: 1, name: 'A' }];
-    expect(hasUniqueObjects(items, 'id')).toBe(true);
+    expect(hasUniqueEntries(items, 'id')).toBe(true);
   });
 
   test('throws an error for a non-existing field', () => {
@@ -34,7 +34,7 @@ describe(hasUniqueObjects.name, () => {
       { id: 1, name: 'A' },
       { id: 2, name: 'B' },
     ];
-    expect(() => hasUniqueObjects(items, 'nonExistingField')).toThrow('unknown field:nonExistingField on array item');
+    expect(() => hasUniqueEntries(items, 'nonExistingField')).toThrow('unknown field:nonExistingField on array item');
   });
 
   test('returns false for duplicates in non-primary field', () => {
@@ -42,16 +42,16 @@ describe(hasUniqueObjects.name, () => {
       { id: 1, name: 'A' },
       { id: 2, name: 'A' },
     ];
-    expect(hasUniqueObjects(items, 'name')).toBe(false);
+    expect(hasUniqueEntries(items, 'name')).toBe(false);
   });
 
   test('throws an error given an array of primitives', () => {
     const items = [1, 2, 3, 1];
-    expect(() => hasUniqueObjects(items as any, 'id')).toThrow('unknown field:id on array item');
+    expect(() => hasUniqueEntries(items as any, 'id')).toThrow('unknown field:id on array item');
   });
 
   test('throws an error given an array of different object structures', () => {
     const items = [{ id: 1, name: 'A' }, { id: 2, name: 'B' }, 3];
-    expect(() => hasUniqueObjects(items, 'id')).toThrow('unknown field:id on array item');
+    expect(() => hasUniqueEntries(items, 'id')).toThrow('unknown field:id on array item');
   });
 });

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -1,4 +1,4 @@
-export function hasUniqueObjects(items: Array<any>, field: string) {
+export function hasUniqueObjects(items: Array<any>, field: string): boolean {
   const uniqueFields = new Set();
 
   const duplicates = items.filter((item) => {

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -1,0 +1,17 @@
+export function hasUniqueObjects(items: Array<any>, field: string) {
+  const uniqueFields = new Set();
+
+  const duplicates = items.filter((item) => {
+    if (!item[field]) {
+      throw new Error(`unknown field:${field} on array item`);
+    }
+
+    if (uniqueFields.has(item[field])) {
+      return true;
+    }
+    uniqueFields.add(item[field]);
+    return false;
+  });
+
+  return duplicates.length === 0;
+}

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -1,4 +1,4 @@
-export function hasUniqueObjects(items: Array<any>, field: string): boolean {
+export function hasUniqueEntries(items: Array<any>, field: string): boolean {
   const uniqueFields = new Set();
 
   const duplicates = items.filter((item) => {


### PR DESCRIPTION
## Changes

Replaces `providerUrl` with a `providers` array as outlined in the comment here: https://github.com/api3dao/chains/issues/103#issuecomment-1759807602


Closes: https://github.com/api3dao/chains/issues/103 and https://github.com/api3dao/chains/issues/4