### PR TITLE
Add zkSync (and testnet) hardhat config network overrides

### DIFF
--- a/chains/zksync-goerli-testnet.json
+++ b/chains/zksync-goerli-testnet.json
@@ -8,5 +8,10 @@
   "explorer": {
     "browserUrl": "https://goerli.explorer.zksync.io/"
   },
-  "blockTimeMs": 1069
+  "blockTimeMs": 1069,
+  "hardhatConfigOverrides": {
+    "ethNetwork": "ethereum-goerli-testnet",
+    "zksync": true,
+    "verifyURL": "https://zksync2-testnet-explorer.zksync.dev/contract_verification"
+  }
 }

--- a/chains/zksync-goerli-testnet.json
+++ b/chains/zksync-goerli-testnet.json
@@ -10,8 +10,10 @@
   },
   "blockTimeMs": 1069,
   "hardhatConfigOverrides": {
-    "ethNetwork": "ethereum-goerli-testnet",
-    "zksync": true,
-    "verifyURL": "https://zksync2-testnet-explorer.zksync.dev/contract_verification"
+    "networks": {
+      "ethNetwork": "ethereum-goerli-testnet",
+      "zksync": true,
+      "verifyURL": "https://zksync2-testnet-explorer.zksync.dev/contract_verification"
+    }
   }
 }

--- a/chains/zksync.json
+++ b/chains/zksync.json
@@ -8,5 +8,10 @@
   "explorer": {
     "browserUrl": "https://explorer.zksync.io/"
   },
-  "blockTimeMs": 1020
+  "blockTimeMs": 1020,
+  "hardhatConfigOverrides": {
+    "ethNetwork": "ethereum",
+    "zksync": true,
+    "verifyURL": "https://zksync2-mainnet-explorer.zksync.io/contract_verification"
+  }
 }

--- a/chains/zksync.json
+++ b/chains/zksync.json
@@ -10,8 +10,10 @@
   },
   "blockTimeMs": 1020,
   "hardhatConfigOverrides": {
-    "ethNetwork": "ethereum",
-    "zksync": true,
-    "verifyURL": "https://zksync2-mainnet-explorer.zksync.io/contract_verification"
+    "networks": {
+      "ethNetwork": "ethereum",
+      "zksync": true,
+      "verifyURL": "https://zksync2-mainnet-explorer.zksync.io/contract_verification"
+    }
   }
 }

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -659,6 +659,11 @@ export const CHAINS: Chain[] = [
     providerUrl: 'https://testnet.era.zksync.dev',
     explorer: { browserUrl: 'https://goerli.explorer.zksync.io/' },
     blockTimeMs: 1069,
+    hardhatConfigOverrides: {
+      ethNetwork: 'ethereum-goerli-testnet',
+      zksync: true,
+      verifyURL: 'https://zksync2-testnet-explorer.zksync.dev/contract_verification',
+    },
   },
   {
     name: 'zkSync',
@@ -669,5 +674,10 @@ export const CHAINS: Chain[] = [
     providerUrl: 'https://mainnet.era.zksync.io',
     explorer: { browserUrl: 'https://explorer.zksync.io/' },
     blockTimeMs: 1020,
+    hardhatConfigOverrides: {
+      ethNetwork: 'ethereum',
+      zksync: true,
+      verifyURL: 'https://zksync2-mainnet-explorer.zksync.io/contract_verification',
+    },
   },
 ];

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -660,9 +660,11 @@ export const CHAINS: Chain[] = [
     explorer: { browserUrl: 'https://goerli.explorer.zksync.io/' },
     blockTimeMs: 1069,
     hardhatConfigOverrides: {
-      ethNetwork: 'ethereum-goerli-testnet',
-      zksync: true,
-      verifyURL: 'https://zksync2-testnet-explorer.zksync.dev/contract_verification',
+      networks: {
+        ethNetwork: 'ethereum-goerli-testnet',
+        zksync: true,
+        verifyURL: 'https://zksync2-testnet-explorer.zksync.dev/contract_verification',
+      },
     },
   },
   {
@@ -675,9 +677,11 @@ export const CHAINS: Chain[] = [
     explorer: { browserUrl: 'https://explorer.zksync.io/' },
     blockTimeMs: 1020,
     hardhatConfigOverrides: {
-      ethNetwork: 'ethereum',
-      zksync: true,
-      verifyURL: 'https://zksync2-mainnet-explorer.zksync.io/contract_verification',
+      networks: {
+        ethNetwork: 'ethereum',
+        zksync: true,
+        verifyURL: 'https://zksync2-mainnet-explorer.zksync.io/contract_verification',
+      },
     },
   },
 ];

--- a/src/hardhat-config.test.ts
+++ b/src/hardhat-config.test.ts
@@ -195,10 +195,13 @@ describe(networks.name, () => {
     expect(Object.keys(result).length).toEqual(CHAINS.length);
 
     CHAINS.forEach((chain) => {
+      const overrides = chain.hardhatConfigOverrides || {};
+
       expect(result[chain.alias]).toEqual({
         accounts: { mnemonic: '' },
         chainId: Number(chain.id),
         url: chain.providerUrl,
+        ...overrides,
       });
     });
   });
@@ -207,10 +210,13 @@ describe(networks.name, () => {
     process.env.MNEMONIC = 'test test test test test test test test test test test junk';
     const result = networks();
     CHAINS.forEach((chain) => {
+      const overrides = chain.hardhatConfigOverrides || {};
+
       expect(result[chain.alias]).toEqual({
         accounts: { mnemonic: 'test test test test test test test test test test test junk' },
         chainId: Number(chain.id),
         url: chain.providerUrl,
+        ...overrides,
       });
     });
   });
@@ -224,10 +230,43 @@ describe(networks.name, () => {
     const result = networks();
 
     CHAINS.forEach((chain) => {
+      const overrides = chain.hardhatConfigOverrides || {};
+
       expect(result[chain.alias]).toEqual({
         accounts: { mnemonic: '' },
         chainId: Number(chain.id),
         url: `https://${chain.id}.xyz`,
+        ...overrides,
+      });
+    });
+  });
+
+  describe('hardhatConfigOverrides', () => {
+    test('has overrides for zksync', () => {
+      const alias = 'zksync';
+      const chain = CHAINS.find((chain) => chain.alias === alias)!;
+
+      expect(networks()[alias]).toEqual({
+        accounts: { mnemonic: '' },
+        chainId: Number(chain.id),
+        ethNetwork: 'ethereum',
+        url: chain.providerUrl,
+        verifyURL: 'https://zksync2-mainnet-explorer.zksync.io/contract_verification',
+        zksync: true,
+      });
+    });
+
+    test('has overrides for zksync-goerli-testnet', () => {
+      const alias = 'zksync-goerli-testnet';
+      const chain = CHAINS.find((chain) => chain.alias === alias)!;
+
+      expect(networks()[alias]).toEqual({
+        accounts: { mnemonic: '' },
+        chainId: Number(chain.id),
+        ethNetwork: 'ethereum-goerli-testnet',
+        url: chain.providerUrl,
+        verifyURL: 'https://zksync2-testnet-explorer.zksync.dev/contract_verification',
+        zksync: true,
       });
     });
   });

--- a/src/hardhat-config.test.ts
+++ b/src/hardhat-config.test.ts
@@ -242,21 +242,7 @@ describe(networks.name, () => {
   });
 
   describe('hardhatConfigOverrides', () => {
-    test('has overrides for zksync', () => {
-      const alias = 'zksync';
-      const chain = CHAINS.find((chain) => chain.alias === alias)!;
-
-      expect(networks()[alias]).toEqual({
-        accounts: { mnemonic: '' },
-        chainId: Number(chain.id),
-        ethNetwork: 'ethereum',
-        url: chain.providerUrl,
-        verifyURL: 'https://zksync2-mainnet-explorer.zksync.io/contract_verification',
-        zksync: true,
-      });
-    });
-
-    test('has overrides for zksync-goerli-testnet', () => {
+    test('zksync-goerli-testnet', () => {
       const alias = 'zksync-goerli-testnet';
       const chain = CHAINS.find((chain) => chain.alias === alias)!;
 
@@ -266,6 +252,20 @@ describe(networks.name, () => {
         ethNetwork: 'ethereum-goerli-testnet',
         url: chain.providerUrl,
         verifyURL: 'https://zksync2-testnet-explorer.zksync.dev/contract_verification',
+        zksync: true,
+      });
+    });
+
+    test('zksync', () => {
+      const alias = 'zksync';
+      const chain = CHAINS.find((chain) => chain.alias === alias)!;
+
+      expect(networks()[alias]).toEqual({
+        accounts: { mnemonic: '' },
+        chainId: Number(chain.id),
+        ethNetwork: 'ethereum',
+        url: chain.providerUrl,
+        verifyURL: 'https://zksync2-mainnet-explorer.zksync.io/contract_verification',
         zksync: true,
       });
     });

--- a/src/hardhat-config.test.ts
+++ b/src/hardhat-config.test.ts
@@ -195,7 +195,7 @@ describe(networks.name, () => {
     expect(Object.keys(result).length).toEqual(CHAINS.length);
 
     CHAINS.forEach((chain) => {
-      const overrides = chain.hardhatConfigOverrides || {};
+      const overrides = chain.hardhatConfigOverrides?.networks || {};
 
       expect(result[chain.alias]).toEqual({
         accounts: { mnemonic: '' },
@@ -210,7 +210,7 @@ describe(networks.name, () => {
     process.env.MNEMONIC = 'test test test test test test test test test test test junk';
     const result = networks();
     CHAINS.forEach((chain) => {
-      const overrides = chain.hardhatConfigOverrides || {};
+      const overrides = chain.hardhatConfigOverrides?.networks || {};
 
       expect(result[chain.alias]).toEqual({
         accounts: { mnemonic: 'test test test test test test test test test test test junk' },
@@ -230,7 +230,7 @@ describe(networks.name, () => {
     const result = networks();
 
     CHAINS.forEach((chain) => {
-      const overrides = chain.hardhatConfigOverrides || {};
+      const overrides = chain.hardhatConfigOverrides?.networks || {};
 
       expect(result[chain.alias]).toEqual({
         accounts: { mnemonic: '' },

--- a/src/hardhat-config.ts
+++ b/src/hardhat-config.ts
@@ -65,7 +65,7 @@ export function networks(): HardhatNetworksConfig {
   }
 
   return CHAINS.reduce((networks, chain) => {
-    const overrides = chain.hardhatConfigOverrides || {};
+    const overrides = chain.hardhatConfigOverrides?.networks || {};
 
     networks[chain.alias] = {
       accounts: { mnemonic: process.env.MNEMONIC || '' },

--- a/src/hardhat-config.ts
+++ b/src/hardhat-config.ts
@@ -65,10 +65,13 @@ export function networks(): HardhatNetworksConfig {
   }
 
   return CHAINS.reduce((networks, chain) => {
+    const overrides = chain.hardhatConfigOverrides || {};
+
     networks[chain.alias] = {
       accounts: { mnemonic: process.env.MNEMONIC || '' },
       chainId: Number(chain.id),
       url: process.env[networkHttpRpcUrlName(chain)] || chain.providerUrl,
+      ...overrides,
     };
     return networks;
   }, {} as HardhatNetworksConfig);

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ export const chainSchema = z.object({
   testnet: z.boolean(),
   explorer: chainExplorerSchema,
   blockTimeMs: z.number().positive(),
-  hardhatConfigOverrides: z.record(z.string(), z.any()).optional()
+  hardhatConfigOverrides: z.record(z.string(), z.any()).optional(),
 });
 
 export type Chain = z.infer<typeof chainSchema>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,10 @@ export const chainExplorerSchema = z.object({
   browserUrl: z.string().url(),
 });
 
+export const hardhatConfigOverrides = z.object({
+  networks: z.record(z.string(), z.any()).optional(),
+});
+
 export const chainSchema = z.object({
   alias: z.string(),
   name: z.string(),
@@ -27,7 +31,7 @@ export const chainSchema = z.object({
   testnet: z.boolean(),
   explorer: chainExplorerSchema,
   blockTimeMs: z.number().positive(),
-  hardhatConfigOverrides: z.record(z.string(), z.any()).optional(),
+  hardhatConfigOverrides: hardhatConfigOverrides.optional(),
 });
 
 export type Chain = z.infer<typeof chainSchema>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export const chainSchema = z.object({
   testnet: z.boolean(),
   explorer: chainExplorerSchema,
   blockTimeMs: z.number().positive(),
+  hardhatConfigOverrides: z.record(z.string(), z.any()).optional()
 });
 
 export type Chain = z.infer<typeof chainSchema>;


### PR DESCRIPTION
## Features

Adds a new optional `hardhatConfigOverrides` object for each chain. This object can an optional `networks` object (leaving space for future customisations later). If a chain has network overrides, these get merged with the existing results from calling `hardhatConfig.networks()`. I've added specific tests for the chains with these overrides (`zksync` and `zksync-goerli-testnet`).

Closes: https://github.com/api3dao/chains/issues/55