### PR TITLE
Viem RPC URL environment variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ console.log(hardhatConfig.getEnvVariableNames());
 
 Returns an array of chains in the format that [Viem](https://viem.sh/docs/clients/chains.html) expects. Each Chain object can be used to [create a Viem public client](https://viem.sh/docs/clients/chains.html#usage).
 
+Additional `rpcUrls` values can (optionally) be added through the use of environment variables. These environment variables take the form of `API3_CHAINS_HTTP_RPC_URL_${toUpperSnakeCase(chain.alias)}`. If a matching environment variable is detected for a given chain, then it is added as a new `environment` property and you still have access to the existing `rpcUrls`.
+
 ```ts
 import { viemConfig } from '@api3/chains';
 console.log(viemConfig.chains());
@@ -124,9 +126,7 @@ console.log(viemConfig.chains());
     id: 421613,
     name: 'arbitrum-goerli-testnet',
     network: 'arbitrum-goerli-testnet',
-    nativeCurrency: { ... },
-    rpcUrls: { default: ..., public: ... }
-    blockExplorers: { default: ..., public: ... }
+    rpcUrls: { default: ..., public: ..., environment: ... }
     ...
   },
   ...

--- a/src/hardhat-config.ts
+++ b/src/hardhat-config.ts
@@ -17,6 +17,10 @@ export function etherscanApiKeyName(chain: Chain): string {
 }
 
 export function networkHttpRpcUrlName(chain: Chain): string {
+  // TODO: we might want to synchronise this with the way viemConfig.chains() sources
+  // env level RPC values. i.e. replacing the "HARHDAT_" prefix with something more generic
+  // Latest suggestion is "API3_CHAINS_" instead.
+  // See thread: https://github.com/api3dao/chains/pull/125/files#r1384859991
   return `HARDHAT_HTTP_RPC_URL_${toUpperSnakeCase(chain.alias)}`;
 }
 

--- a/src/viem-config.test.ts
+++ b/src/viem-config.test.ts
@@ -1,0 +1,108 @@
+import { chains, chainHttpRpcUrlName } from './viem-config';
+import { Chain } from './types';
+import { CHAINS } from './generated/chains';
+import { toUpperSnakeCase } from './utils/strings';
+
+function getRandomChain(): Chain {
+  return CHAINS[Math.floor(Math.random() * CHAINS.length)]!;
+}
+
+const OLD_ENV = process.env;
+
+beforeEach(() => {
+  jest.resetModules(); // Most important - it clears the cache
+  process.env = { ...OLD_ENV }; // Make a copy
+});
+
+afterAll(() => {
+  process.env = OLD_ENV; // Restore old environment
+});
+
+describe(chainHttpRpcUrlName.name, () => {
+  test('returns the expected HTTP RPC URL name', () => {
+    const randomChain = getRandomChain();
+    const expected = `VIEM_HTTP_RPC_URL_${toUpperSnakeCase(randomChain!.alias)}`;
+    expect(chainHttpRpcUrlName(randomChain!)).toStrictEqual(expected);
+  });
+});
+
+describe(chains.name, () => {
+  test('returns the list of all chains compatible with Viem', () => {
+    const result = chains();
+    expect(result.length).toEqual(CHAINS.length);
+
+    CHAINS.forEach((chain) => {
+      const defaultProvider = chain.providers.find((p) => p.alias === 'default')!;
+      const currencyName = chain.testnet ? `Testnet ${chain.symbol}` : chain.symbol;
+
+      const res = result.find((r) => r.id.toString() === chain.id);
+      expect(res).toEqual({
+        id: Number(chain.id),
+        name: chain.alias,
+        network: chain.alias,
+        nativeCurrency: {
+          name: currencyName,
+          symbol: chain.symbol,
+          decimals: chain.decimals,
+        },
+        rpcUrls: {
+          default: {
+            http: [defaultProvider.rpcUrl!],
+          },
+          public: {
+            http: [defaultProvider.rpcUrl!],
+          },
+        },
+        blockExplorers: {
+          default: {
+            name: 'Explorer',
+            url: chain.explorer.browserUrl,
+          },
+        },
+      });
+    });
+  });
+
+  test('allows for setting additional RPC URL values with env variables', () => {
+    CHAINS.forEach((chain) => {
+      const alias = toUpperSnakeCase(chain.alias);
+      process.env[`VIEM_HTTP_RPC_URL_${alias}`] = `https://${chain.id}.xyz`;
+    });
+
+    const result = chains();
+
+    CHAINS.forEach((chain) => {
+      const defaultProvider = chain.providers.find((p) => p.alias === 'default')!;
+      const currencyName = chain.testnet ? `Testnet ${chain.symbol}` : chain.symbol;
+
+      const res = result.find((r) => r.id.toString() === chain.id);
+      expect(res).toEqual({
+        id: Number(chain.id),
+        name: chain.alias,
+        network: chain.alias,
+        nativeCurrency: {
+          name: currencyName,
+          symbol: chain.symbol,
+          decimals: chain.decimals,
+        },
+        rpcUrls: {
+          default: {
+            http: [defaultProvider.rpcUrl!],
+          },
+          public: {
+            http: [defaultProvider.rpcUrl!],
+          },
+          environment: {
+            http: [`https://${chain.id}.xyz`],
+          }
+        },
+        blockExplorers: {
+          default: {
+            name: 'Explorer',
+            url: chain.explorer.browserUrl,
+          },
+        },
+      });
+    });
+  });
+});

--- a/src/viem-config.test.ts
+++ b/src/viem-config.test.ts
@@ -1,4 +1,4 @@
-import { chains, chainHttpRpcUrlName } from './viem-config';
+import { chainHttpRpcUrlName, chains } from './viem-config';
 import { Chain } from './types';
 import { CHAINS } from './generated/chains';
 import { toUpperSnakeCase } from './utils/strings';

--- a/src/viem-config.test.ts
+++ b/src/viem-config.test.ts
@@ -21,7 +21,7 @@ afterAll(() => {
 describe(chainHttpRpcUrlName.name, () => {
   test('returns the expected HTTP RPC URL name', () => {
     const randomChain = getRandomChain();
-    const expected = `VIEM_HTTP_RPC_URL_${toUpperSnakeCase(randomChain!.alias)}`;
+    const expected = `API3_CHAINS_HTTP_RPC_URL_${toUpperSnakeCase(randomChain!.alias)}`;
     expect(chainHttpRpcUrlName(randomChain!)).toStrictEqual(expected);
   });
 });
@@ -66,7 +66,7 @@ describe(chains.name, () => {
   test('allows for setting additional RPC URL values with env variables', () => {
     CHAINS.forEach((chain) => {
       const alias = toUpperSnakeCase(chain.alias);
-      process.env[`VIEM_HTTP_RPC_URL_${alias}`] = `https://${chain.id}.xyz`;
+      process.env[`API3_CHAINS_HTTP_RPC_URL_${alias}`] = `https://${chain.id}.xyz`;
     });
 
     const result = chains();

--- a/src/viem-config.test.ts
+++ b/src/viem-config.test.ts
@@ -94,7 +94,7 @@ describe(chains.name, () => {
           },
           environment: {
             http: [`https://${chain.id}.xyz`],
-          }
+          },
         },
         blockExplorers: {
           default: {

--- a/src/viem-config.ts
+++ b/src/viem-config.ts
@@ -4,7 +4,7 @@ import { CHAINS } from './generated/chains';
 import { toUpperSnakeCase } from './utils/strings';
 
 export function chainHttpRpcUrlName(chain: Chain) {
-  return `VIEM_HTTP_RPC_URL_${toUpperSnakeCase(chain.alias)}`;
+  return `API3_CHAINS_HTTP_RPC_URL_${toUpperSnakeCase(chain.alias)}`;
 }
 
 export function chains() {

--- a/src/viem-config.ts
+++ b/src/viem-config.ts
@@ -1,11 +1,18 @@
 import { defineChain } from 'viem';
 import { Chain } from './types';
 import { CHAINS } from './generated/chains';
+import { toUpperSnakeCase } from './utils/strings';
+
+export function chainHttpRpcUrlName(chain: Chain) {
+  return `VIEM_HTTP_RPC_URL_${toUpperSnakeCase(chain.alias)}`;
+}
 
 export function chains() {
   return CHAINS.map((chain) => {
     // All chains must have at least a default provider
     const defaultProvider = chain.providers.find((c) => c.alias === 'default')!;
+    const envRpcUrl = process.env[chainHttpRpcUrlName(chain)];
+    const extraRpcUrls = envRpcUrl ? { environment: { http: [envRpcUrl] } } : {};
 
     return defineChain({
       id: Number(chain.id),
@@ -23,6 +30,7 @@ export function chains() {
         public: {
           http: [defaultProvider.rpcUrl!],
         },
+        ...extraRpcUrls,
       },
       blockExplorers: {
         default: {


### PR DESCRIPTION
# Changes

Currently Hardhat allows for [overriding the `url` field](https://github.com/api3dao/chains/blob/2a4cd589ab14b61c2ed2b3bd69d10617f42d6c5e/src/hardhat-config.ts#L74) of each network if a specific environment variable is found (`HARDHAT_HTTP_RPC_URL_${toUpperSnakeCase(chain.alias)}`)

This PR implements a similar feature for `viemConfig.chains()` to maintain some level of parity. I first had it replace the `rpcUrls.public` and `rpcUrls.default` values if the env variable exists, but then figured we could just keep those exposed and add a new field if the new env variable is found (`API3_CHAINS_HTTP_RPC_URL_${toUpperSnakeCase(chain.alias)}`).

Let me know what you think