### PR TITLE
Update Avalanche block explorer API URL

### DIFF
--- a/chains/avalanche-testnet.json
+++ b/chains/avalanche-testnet.json
@@ -8,7 +8,7 @@
         "hardhatEtherscanAlias": "avalancheFujiTestnet",
         "required": true
       },
-      "url": "https://api-testnet.snowtrace.io/api"
+      "url": "https://api.routescan.io/v2/network/testnet/evm/43113/etherscan/api"
     },
     "browserUrl": "https://testnet.snowtrace.io/"
   },

--- a/chains/avalanche.json
+++ b/chains/avalanche.json
@@ -8,7 +8,7 @@
         "hardhatEtherscanAlias": "avalanche",
         "required": true
       },
-      "url": "https://api.snowtrace.io/api"
+      "url": "https://api.routescan.io/v2/network/mainnet/evm/43114/etherscan/api"
     },
     "browserUrl": "https://snowtrace.io/"
   },

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -94,7 +94,7 @@ export const CHAINS: Chain[] = [
     explorer: {
       api: {
         key: { hardhatEtherscanAlias: 'avalancheFujiTestnet', required: true },
-        url: 'https://api-testnet.snowtrace.io/api',
+        url: 'https://api.routescan.io/v2/network/testnet/evm/43113/etherscan/api',
       },
       browserUrl: 'https://testnet.snowtrace.io/',
     },
@@ -109,7 +109,10 @@ export const CHAINS: Chain[] = [
     blockTimeMs: 2036,
     decimals: 18,
     explorer: {
-      api: { key: { hardhatEtherscanAlias: 'avalanche', required: true }, url: 'https://api.snowtrace.io/api' },
+      api: {
+        key: { hardhatEtherscanAlias: 'avalanche', required: true },
+        url: 'https://api.routescan.io/v2/network/mainnet/evm/43114/etherscan/api',
+      },
       browserUrl: 'https://snowtrace.io/',
     },
     id: '43114',


### PR DESCRIPTION
Closes https://github.com/api3dao/chains/issues/111

As expected, they moved the new block explorer to the URL of the old one so no changes needed there. The API URL changed though. I verified contracts with these values so I know that they work.