### PR TITLE
Add optional skipProviderCheck field to chain schema

### DIFF
--- a/scripts/ping-providers.ts
+++ b/scripts/ping-providers.ts
@@ -17,6 +17,9 @@ const slackClient = new WebClient(slackToken);
 
 async function main(): Promise<PromiseSettledResult<void>[]> {
   const promises = chains.map(async (chain) => {
+    // Skip the provider check for chains not supporting dAPIs
+    if (chain.skipProviderCheck) return;
+
     // Every chain should have at least a default provider with an RPC URL
     const defaultProvider = chain.providers.find((p) => p.alias === 'default')!;
     const client = createPublicClient({ transport: http(defaultProvider.rpcUrl!) });

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,7 @@ export const chainSchema = z
     explorer: chainExplorerSchema,
     blockTimeMs: z.number().positive(),
     hardhatConfigOverrides: hardhatConfigOverrides.optional(),
+    skipProviderCheck: z.boolean().optional(), // For chains not supporting dAPIs
   })
   .superRefine((chain, ctx) => {
     if (chain.testnet && !chain.symbol.startsWith('test')) {


### PR DESCRIPTION
Allows addition of chains that don't support dAPIs. Closes #153.

I tested this by:
1. changing the `default` `rpcUrl` to nonsense for `arbitrum-goerli-testnet.json`, running `yarn generate:chains` and confirming that an error was returned when running `export CHAIN=arbitrum-goerli-testnet; yarn providers:ping`
2. then I added `"skipProviderCheck": true`, reran `yarn generate:chains`, and the ping command passed