### PR TITLE
Add Blast Sepolia Testnet

### DIFF
--- a/chains/blast-sepolia-testnet.json
+++ b/chains/blast-sepolia-testnet.json
@@ -1,0 +1,25 @@
+{
+  "alias": "blast-sepolia-testnet",
+  "blockTimeMs": 2000,
+  "decimals": 18,
+  "explorer": {
+    "api": {
+      "key": {
+        "required": true
+      },
+      "url": "https://api.routescan.io/v2/network/testnet/evm/168587773/etherscan/api"
+    },
+    "browserUrl": "https://testnet.blastscan.io/"
+  },
+  "id": "168587773",
+  "name": "Blast Sepolia Testnet",
+  "providers": [
+    {
+      "alias": "default",
+      "rpcUrl": "https://sepolia.blast.io"
+    }
+  ],
+  "skipProviderCheck": true,
+  "symbol": "testETH",
+  "testnet": true
+}

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -176,6 +176,21 @@ export const CHAINS: Chain[] = [
     testnet: false,
   },
   {
+    alias: 'blast-sepolia-testnet',
+    blockTimeMs: 2000,
+    decimals: 18,
+    explorer: {
+      api: { key: { required: true }, url: 'https://api.routescan.io/v2/network/testnet/evm/168587773/etherscan/api' },
+      browserUrl: 'https://testnet.blastscan.io/',
+    },
+    id: '168587773',
+    name: 'Blast Sepolia Testnet',
+    providers: [{ alias: 'default', rpcUrl: 'https://sepolia.blast.io' }],
+    skipProviderCheck: true,
+    symbol: 'testETH',
+    testnet: true,
+  },
+  {
     alias: 'boba-bnb',
     blockTimeMs: 636,
     decimals: 18,


### PR DESCRIPTION
Addded `blast-sepolia-testnet`. We recently deployed the Testnet Random Numbers QRNG Provider there.
[Blast Sepolia Testnet](https://testnet.blastscan.io/)
[AirnodeRrpV0.sol](https://testnet.blastscan.io/address/0xD223DfDCb888CA1539bb3459a83c543A1608F038)