### PR TITLE
Update `default` provider for `ethereum`

### DIFF
--- a/chains/ethereum.json
+++ b/chains/ethereum.json
@@ -17,7 +17,7 @@
   "providers": [
     {
       "alias": "default",
-      "rpcUrl": "https://eth.llamarpc.com"
+      "rpcUrl": "https://cloudflare-eth.com"
     },
     {
       "alias": "reblok",

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -316,7 +316,7 @@ export const CHAINS: Chain[] = [
     id: '1',
     name: 'Ethereum',
     providers: [
-      { alias: 'default', rpcUrl: 'https://eth.llamarpc.com' },
+      { alias: 'default', rpcUrl: 'https://cloudflare-eth.com' },
       { alias: 'reblok', homepageUrl: 'https://reblok.io' },
       { alias: 'quicknode', homepageUrl: 'https://quicknode.com' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org/' },


### PR DESCRIPTION
The current `default` provider for `ethereum` occasionally encounters reliability issues. This PR suggests replacing it with a more dependable alternative.