### PR TITLE
Update `default` provider for `ethereum-sepolia-testnet`

### DIFF
--- a/chains/ethereum-sepolia-testnet.json
+++ b/chains/ethereum-sepolia-testnet.json
@@ -17,7 +17,7 @@
   "providers": [
     {
       "alias": "default",
-      "rpcUrl": "https://rpc-sepolia.rockx.com"
+      "rpcUrl": "https://sepolia.gateway.tenderly.co"
     },
     {
       "alias": "publicnode",

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -298,7 +298,7 @@ export const CHAINS: Chain[] = [
     id: '11155111',
     name: 'Ethereum Sepolia testnet',
     providers: [
-      { alias: 'default', rpcUrl: 'https://rpc-sepolia.rockx.com' },
+      { alias: 'default', rpcUrl: 'https://sepolia.gateway.tenderly.co' },
       { alias: 'publicnode', rpcUrl: 'https://ethereum-sepolia.publicnode.com' },
       { alias: 'reblok', homepageUrl: 'https://reblok.io' },
     ],


### PR DESCRIPTION
The current `default` provider for `ethereum-sepolia-testnet` has been non-functional for approximately 5 hours. This PR proposes replacing it with a functional alternative.