### PR TITLE
Fix Lightlink block explorer API key flag

### DIFF
--- a/chains/lightlink-goerli-testnet.json
+++ b/chains/lightlink-goerli-testnet.json
@@ -5,7 +5,7 @@
   "explorer": {
     "api": {
       "key": {
-        "required": true
+        "required": false
       },
       "url": "https://pegasus.lightlink.io/api"
     },

--- a/chains/lightlink.json
+++ b/chains/lightlink.json
@@ -5,7 +5,7 @@
   "explorer": {
     "api": {
       "key": {
-        "required": true
+        "required": false
       },
       "url": "https://phoenix.lightlink.io/api"
     },

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -458,7 +458,7 @@ export const CHAINS: Chain[] = [
     blockTimeMs: 502,
     decimals: 18,
     explorer: {
-      api: { key: { required: true }, url: 'https://pegasus.lightlink.io/api' },
+      api: { key: { required: false }, url: 'https://pegasus.lightlink.io/api' },
       browserUrl: 'https://pegasus.lightlink.io/',
     },
     id: '1891',
@@ -473,7 +473,7 @@ export const CHAINS: Chain[] = [
     blockTimeMs: 505,
     decimals: 18,
     explorer: {
-      api: { key: { required: true }, url: 'https://phoenix.lightlink.io/api' },
+      api: { key: { required: false }, url: 'https://phoenix.lightlink.io/api' },
       browserUrl: 'https://phoenix.lightlink.io/',
     },
     id: '1890',


### PR DESCRIPTION
I was looking for a chain to test my deployment scripts on and noticed that this is wrong