### PR TITLE
Add GitHub Action to refresh block times

### DIFF
--- a/.github/workflows/refresh-block-time.yml
+++ b/.github/workflows/refresh-block-time.yml
@@ -1,0 +1,41 @@
+name: Refresh Block Times
+
+on:
+  schedule:
+    # Run once a month
+    - cron: '0 12 1 * *'
+
+jobs:
+  refresh-block-times:
+    runs-on: ubuntu-latest
+    env:
+      branchName: action-refresh-block-time
+    steps:
+      - name: Clone @api3/chains
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run providers:time
+        run: |
+          yarn providers:time
+          yarn generate:chains
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com>"
+          git checkout -b ${{ env.branchName }}
+          git commit -am "Refresh block times"
+          git push origin HEAD
+
+      - name: Create pull request
+        run: gh pr create -B main -H ${{ env.branchName }} --title 'Refresh Block Times' --body 'Created by GitGub Action'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/refresh-block-time.yml
+++ b/.github/workflows/refresh-block-time.yml
@@ -12,7 +12,7 @@ jobs:
       branchName: action-refresh-block-time
     steps:
       - name: Clone @api3/chains
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/refresh-block-time.yml
+++ b/.github/workflows/refresh-block-time.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
 


### PR DESCRIPTION
Closes #165. Tested in my fork: here is the [action run](https://github.com/dcroote/chains/actions/runs/7896924464/job/21551656185) and the [resulting PR](https://github.com/dcroote/chains/pull/1). Note for testing on my fork I had a manual trigger that I removed for this PR. Also note there isn't caching since [GitHub evicts cache entries older than 7 days](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy) and since this is planned for monthly, caching won't help.