### PR TITLE
Add provider `reblok` for the chain `blast`

### DIFF
--- a/chains/blast.json
+++ b/chains/blast.json
@@ -17,6 +17,10 @@
     {
       "alias": "default",
       "rpcUrl": "https://rpc.blast.io"
+    },
+    {
+      "alias": "reblok",
+      "homepageUrl": "https://reblok.io"
     }
   ],
   "skipProviderCheck": false,

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -218,7 +218,10 @@ export const CHAINS: Chain[] = [
     },
     id: '81457',
     name: 'Blast',
-    providers: [{ alias: 'default', rpcUrl: 'https://rpc.blast.io' }],
+    providers: [
+      { alias: 'default', rpcUrl: 'https://rpc.blast.io' },
+      { alias: 'reblok', homepageUrl: 'https://reblok.io' },
+    ],
     skipProviderCheck: false,
     symbol: 'ETH',
     testnet: false,


### PR DESCRIPTION
Reblok deployed RPC node for the chain `blast`. 

For your visibility @aquarat @vponline: `proxy.reblok.io/blast/reblok` endpoint has been deployed so you can use it for the collector applications