### PR TITLE
Add mantle-sepolia-testnet

### DIFF
--- a/chains/mantle-sepolia-testnet.json
+++ b/chains/mantle-sepolia-testnet.json
@@ -1,0 +1,24 @@
+{
+  "alias": "mantle-sepolia-testnet",
+  "blockTimeMs": 2000,
+  "decimals": 18,
+  "explorer": {
+    "api": {
+      "key": {
+        "required": false
+      },
+      "url": "https://explorer.sepolia.mantle.xyz/api"
+    },
+    "browserUrl": "https://explorer.sepolia.mantle.xyz/"
+  },
+  "id": "5003",
+  "name": "Mantle Sepolia testnet",
+  "providers": [
+    {
+      "alias": "default",
+      "rpcUrl": "https://rpc.sepolia.mantle.xyz"
+    }
+  ],
+  "symbol": "MNT",
+  "testnet": true
+}

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -570,6 +570,20 @@ export const CHAINS: Chain[] = [
     testnet: true,
   },
   {
+    alias: 'mantle-sepolia-testnet',
+    blockTimeMs: 2000,
+    decimals: 18,
+    explorer: {
+      api: { key: { required: false }, url: 'https://explorer.sepolia.mantle.xyz/api' },
+      browserUrl: 'https://explorer.sepolia.mantle.xyz/',
+    },
+    id: '5003',
+    name: 'Mantle Sepolia testnet',
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.sepolia.mantle.xyz' }],
+    symbol: 'MNT',
+    testnet: true,
+  },
+  {
     alias: 'mantle',
     blockTimeMs: 499,
     decimals: 18,


### PR DESCRIPTION
As a note, I typically add super new chains and `providers:time` fails because the chain doesn't have [400000 blocks](https://github.com/api3dao/chains/blob/main/scripts/calculate-average-block-times.ts#L6) yet, so I reduce that number manually to run the script and end up getting a weird block time such as the 2000 here