### PR TITLE
Do not skip provider check for blast-sepolia-testnet

### DIFF
--- a/chains/blast-sepolia-testnet.json
+++ b/chains/blast-sepolia-testnet.json
@@ -19,7 +19,7 @@
       "rpcUrl": "https://sepolia.blast.io"
     }
   ],
-  "skipProviderCheck": true,
+  "skipProviderCheck": false,
   "symbol": "ETH",
   "testnet": true
 }

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -205,7 +205,7 @@ export const CHAINS: Chain[] = [
     id: '168587773',
     name: 'Blast Sepolia Testnet',
     providers: [{ alias: 'default', rpcUrl: 'https://sepolia.blast.io' }],
-    skipProviderCheck: true,
+    skipProviderCheck: false,
     symbol: 'ETH',
     testnet: true,
   },


### PR DESCRIPTION
This chain is actively maintained. So it's better to not skip provider check for it.