### PR TITLE
Add OEV Network AggLayer testnet

### DIFF
--- a/chains/oev-network-agg-sepolia-testnet.json
+++ b/chains/oev-network-agg-sepolia-testnet.json
@@ -1,0 +1,24 @@
+{
+  "alias": "oev-network-agg-sepolia-testnet",
+  "blockTimeMs": 1686780,
+  "decimals": 18,
+  "explorer": {
+    "api": {
+      "key": {
+        "required": false
+      },
+      "url": "https://oev-network-sepolia-testnet-agg-blockscout.eu-north-2.gateway.fm/api/"
+    },
+    "browserUrl": "https://oev-network-sepolia-testnet-agg-blockscout.eu-north-2.gateway.fm/"
+  },
+  "id": "879490799",
+  "name": "OEV Network Sepolia testnet (AggLayer)",
+  "providers": [
+    {
+      "alias": "default",
+      "rpcUrl": "https://oev-network-sepolia-testnet-agg-rpc.eu-north-2.gateway.fm"
+    }
+  ],
+  "symbol": "ETH",
+  "testnet": true
+}

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -758,6 +758,23 @@ export const CHAINS: Chain[] = [
     testnet: false,
   },
   {
+    alias: 'oev-network-agg-sepolia-testnet',
+    blockTimeMs: 1686780,
+    decimals: 18,
+    explorer: {
+      api: {
+        key: { required: false },
+        url: 'https://oev-network-sepolia-testnet-agg-blockscout.eu-north-2.gateway.fm/api/',
+      },
+      browserUrl: 'https://oev-network-sepolia-testnet-agg-blockscout.eu-north-2.gateway.fm/',
+    },
+    id: '879490799',
+    name: 'OEV Network Sepolia testnet (AggLayer)',
+    providers: [{ alias: 'default', rpcUrl: 'https://oev-network-sepolia-testnet-agg-rpc.eu-north-2.gateway.fm' }],
+    symbol: 'ETH',
+    testnet: true,
+  },
+  {
     alias: 'oev-network-sepolia-testnet',
     blockTimeMs: 1686780,
     decimals: 18,


### PR DESCRIPTION
This one is a bit annoying. I wanted to keep the `l2name-l1name-testnet` convention in the alias (for stuff line `.endsWith('-testnet')`), but Gateway used `oev-network-sepolia-testnet-agg` as the chain name on their end. I guess as soon as we switch to this testnet, we can remove the old one and update the name/alias of this one to not have "agg" in it.