### PR TITLE
Update blast sepolia api and browser urls

### DIFF
--- a/.changeset/nervous-books-travel.md
+++ b/.changeset/nervous-books-travel.md
@@ -1,0 +1,5 @@
+---
+"@api3/chains": patch
+---
+
+Update blast sepolia api and browser urls

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,6 @@
 
 # IDEs
 .vscode
+
+# Changeset
+.changeset

--- a/chains/blast-sepolia-testnet.json
+++ b/chains/blast-sepolia-testnet.json
@@ -5,11 +5,11 @@
   "explorer": {
     "api": {
       "key": {
-        "required": false
+        "required": true
       },
-      "url": "https://api.routescan.io/v2/network/testnet/evm/168587773/etherscan/api"
+      "url": "https://api-sepolia.blastscan.io/api"
     },
-    "browserUrl": "https://testnet.blastscan.io/"
+    "browserUrl": "https://sepolia.blastscan.io/"
   },
   "id": "168587773",
   "name": "Blast Sepolia Testnet",

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -220,8 +220,8 @@ export const CHAINS: Chain[] = [
     blockTimeMs: 2000,
     decimals: 18,
     explorer: {
-      api: { key: { required: false }, url: 'https://api.routescan.io/v2/network/testnet/evm/168587773/etherscan/api' },
-      browserUrl: 'https://testnet.blastscan.io/',
+      api: { key: { required: true }, url: 'https://api-sepolia.blastscan.io/api' },
+      browserUrl: 'https://sepolia.blastscan.io/',
     },
     id: '168587773',
     name: 'Blast Sepolia Testnet',


### PR DESCRIPTION
Closes #213. The URL is per the [docs here](https://docs.blastscan.io/v/sepolia-blastscan). This also now matches the non-testnet blast config:

https://github.com/api3dao/chains/blob/21239109e005aab02f931bee53c5c10c6f8f2cf9/chains/blast.json#L7-L12


Second commit adds a changeset and also adds the .changeset directory to `.prettierignore` which was necessary because prettier was unhappy about the changeset having default double quotes instead of single quotes around the package name