### PR TITLE
Drop unnecessary --frozen-lockfile from CI pnpm install

### DIFF
--- a/.github/workflows/check-providers.yml
+++ b/.github/workflows/check-providers.yml
@@ -3,7 +3,7 @@ name: Check Providers
 on:
   schedule:
     # Run every day at 12:00
-    - cron: "0 12 * * *"
+    - cron: '0 12 * * *'
   pull_request:
     branches:
       - main
@@ -34,8 +34,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Run providers:ping
         run: pnpm providers:ping
-

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -40,7 +40,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Run Build
         run: pnpm build
@@ -74,7 +74,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Check for changeset
         run: pnpm changeset status --since=origin/main

--- a/.github/workflows/refresh-block-time.yml
+++ b/.github/workflows/refresh-block-time.yml
@@ -30,7 +30,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Run providers:time
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Build package
         run: pnpm build
@@ -55,9 +55,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
-          
+
       - name: Create pull request
         if: steps.changesets.outputs.published == 'true'
         run: gh pr create -B main -H production --title 'Merge production into main' --body 'Merges production into main' --reviewer andreogle
         env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`pnpm install` defaults to `true` for `--frozen-lockfile` when running on CI and a lockfile is present (which we have) - [source](https://pnpm.io/cli/install#--frozen-lockfile). Therefore, it's not necessary to include.