### PR TITLE
Add fetch-depth: 0 to release clone step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Clone @api3/chains
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v3


### PR DESCRIPTION
The last [Release action](https://github.com/api3dao/chains/actions/runs/8603532202/job/23575638355#step:7:8) had the error:
```
Run git checkout main
error: pathspec 'main' did not match any file(s) known to git
```

which strangely didn't happen before, but is plausibly explained by the Release workflow being triggered by the `production` branch and having only that branch present. Indeed during the Action:

```
Fetching the repository
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +5938ec727ebf355e41338701fcd8bf0f3feca6d2:refs/remotes/origin/production
  From https://github.com/api3dao/chains
   * [new ref]         5938ec727ebf355e41338701fcd8bf0f3feca6d2 -> origin/production
Determining the checkout info
Checking out the ref
  /usr/bin/git checkout --progress --force -B production refs/remotes/origin/production
  Switched to a new branch 'production'
  branch 'production' set up to track 'origin/production'.
```

Therefore following the actions/checkout [instructions](https://github.com/actions/checkout/tree/v4/?tab=readme-ov-file#checkout-v4): "Set fetch-depth: 0 to fetch all history for all branches and tags" should ensure main is present.