### PR TITLE
Skip provider check for polygon-testnet

### DIFF
--- a/.changeset/bright-experts-juggle.md
+++ b/.changeset/bright-experts-juggle.md
@@ -1,0 +1,5 @@
+---
+"@api3/chains": patch
+---
+
+Skip provider check for polygon-testnet

--- a/chains/polygon-testnet.json
+++ b/chains/polygon-testnet.json
@@ -28,6 +28,7 @@
       "homepageUrl": "https://reblok.io"
     }
   ],
+  "skipProviderCheck": true,
   "symbol": "MATIC",
   "testnet": true
 }

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -984,6 +984,7 @@ export const CHAINS: Chain[] = [
       { alias: 'publicnode', rpcUrl: 'https://polygon-mumbai-bor-rpc.publicnode.com' },
       { alias: 'reblok', homepageUrl: 'https://reblok.io' },
     ],
+    skipProviderCheck: true,
     symbol: 'MATIC',
     testnet: true,
   },


### PR DESCRIPTION
This chain has been deprecated, so it can be disregarded. Additionally, `skipProviderCheck` is being utilized by the app `rpc-watcher`. Consequently, pricing logs will no longer be collected. This change is acceptable, as we are no longer accepting new subscriptions on this chain.

Related to https://github.com/api3dao/tasks/issues/1021.