### PR TITLE
Add chains for `CSUR-2024-05-28`

### DIFF
--- a/.changeset/five-bulldogs-bake.md
+++ b/.changeset/five-bulldogs-bake.md
@@ -1,0 +1,12 @@
+---
+"@api3/chains": minor
+---
+
+Add following chains:
+
+* Sei
+* Taiko
+
+Update explorer links for the following chains:
+
+* Sei testnet

--- a/chains/sei-testnet.json
+++ b/chains/sei-testnet.json
@@ -2,13 +2,7 @@
   "alias": "sei-testnet",
   "decimals": 18,
   "explorer": {
-    "api": {
-      "key": {
-        "required": false
-      },
-      "url": "https://seitrace.com/api"
-    },
-    "browserUrl": "https://seitrace.com/"
+    "browserUrl": "https://devnet.seistream.app/"
   },
   "id": "713715",
   "name": "Sei testnet",

--- a/chains/sei.json
+++ b/chains/sei.json
@@ -1,0 +1,17 @@
+{
+  "alias": "sei",
+  "decimals": 18,
+  "explorer": {
+    "browserUrl": "https://seitrace.com/"
+  },
+  "id": "1329",
+  "name": "Sei",
+  "providers": [
+    {
+      "alias": "default",
+      "rpcUrl": "https://evm-rpc.sei-apis.com/"
+    }
+  ],
+  "symbol": "SEI",
+  "testnet": false
+}

--- a/chains/sei.json
+++ b/chains/sei.json
@@ -10,6 +10,10 @@
     {
       "alias": "default",
       "rpcUrl": "https://evm-rpc.sei-apis.com/"
+    },
+    {
+      "alias": "quicknode",
+      "homepageUrl": "https://quicknode.com"
     }
   ],
   "symbol": "SEI",

--- a/chains/taiko.json
+++ b/chains/taiko.json
@@ -16,6 +16,10 @@
     {
       "alias": "default",
       "rpcUrl": "https://rpc.taiko.xyz"
+    },
+    {
+      "alias": "drpc",
+      "homepageUrl": "https://drpc.org"
     }
   ],
   "symbol": "ETH",

--- a/chains/taiko.json
+++ b/chains/taiko.json
@@ -1,0 +1,23 @@
+{
+  "alias": "taiko",
+  "decimals": 18,
+  "explorer": {
+    "api": {
+      "key": {
+        "required": true
+      },
+      "url": "https://api.taikoscan.io/api"
+    },
+    "browserUrl": "https://taikoscan.io/"
+  },
+  "id": "167000",
+  "name": "Taiko",
+  "providers": [
+    {
+      "alias": "default",
+      "rpcUrl": "https://rpc.taiko.xyz"
+    }
+  ],
+  "symbol": "ETH",
+  "testnet": false
+}

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -1318,10 +1318,7 @@ export const CHAINS: Chain[] = [
   {
     alias: 'sei-testnet',
     decimals: 18,
-    explorer: {
-      api: { key: { required: false }, url: 'https://seitrace.com/api' },
-      browserUrl: 'https://seitrace.com/',
-    },
+    explorer: { browserUrl: 'https://devnet.seistream.app/' },
     id: '713715',
     name: 'Sei testnet',
     providers: [
@@ -1330,6 +1327,16 @@ export const CHAINS: Chain[] = [
     ],
     symbol: 'SEI',
     testnet: true,
+  },
+  {
+    alias: 'sei',
+    decimals: 18,
+    explorer: { browserUrl: 'https://seitrace.com/' },
+    id: '1329',
+    name: 'Sei',
+    providers: [{ alias: 'default', rpcUrl: 'https://evm-rpc.sei-apis.com/' }],
+    symbol: 'SEI',
+    testnet: false,
   },
   {
     alias: 'sx-testnet',
@@ -1369,6 +1376,19 @@ export const CHAINS: Chain[] = [
     providers: [{ alias: 'default', rpcUrl: 'https://rpc.hekla.taiko.xyz' }],
     symbol: 'ETH',
     testnet: true,
+  },
+  {
+    alias: 'taiko',
+    decimals: 18,
+    explorer: {
+      api: { key: { required: true }, url: 'https://api.taikoscan.io/api' },
+      browserUrl: 'https://taikoscan.io/',
+    },
+    id: '167000',
+    name: 'Taiko',
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.taiko.xyz' }],
+    symbol: 'ETH',
+    testnet: false,
   },
   {
     alias: 'x-layer-sepolia-testnet',

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -1334,7 +1334,10 @@ export const CHAINS: Chain[] = [
     explorer: { browserUrl: 'https://seitrace.com/' },
     id: '1329',
     name: 'Sei',
-    providers: [{ alias: 'default', rpcUrl: 'https://evm-rpc.sei-apis.com/' }],
+    providers: [
+      { alias: 'default', rpcUrl: 'https://evm-rpc.sei-apis.com/' },
+      { alias: 'quicknode', homepageUrl: 'https://quicknode.com' },
+    ],
     symbol: 'SEI',
     testnet: false,
   },
@@ -1386,7 +1389,10 @@ export const CHAINS: Chain[] = [
     },
     id: '167000',
     name: 'Taiko',
-    providers: [{ alias: 'default', rpcUrl: 'https://rpc.taiko.xyz' }],
+    providers: [
+      { alias: 'default', rpcUrl: 'https://rpc.taiko.xyz' },
+      { alias: 'drpc', homepageUrl: 'https://drpc.org' },
+    ],
     symbol: 'ETH',
     testnet: false,
   },


### PR DESCRIPTION
Closes #330 

**sei - [bridge](https://app.sei.io/bridge) - [docs](https://www.docs.sei.io/dev-gas)**
---
sei contract verification api is not available ATM but contracts are already verified on `sei-testnet` process. That is being said `sei` uses the same block explorer for both testnet and mainnet chains. Thus to avoid external link errors `sei-testnet` block explorer replaced with an alternative one.

[OwnableCallForwarder](https://seitrace.com/address/0xef455205966486F52f7951ba4C3517239B036835)
[Api3ServerV1](https://seitrace.com/address/0x3ee097B82E270d82f829e5742cC16B7686247Ff2)
[DataFeedProxy](https://seitrace.com/address/0x9Cf90E5B9292a82B214925f0b707779E0aFa0F74)
[DapiProxy](https://seitrace.com/address/0x73Eb8A060e52efC2513861282Ff62B9182daC5c6)
[DataFeedProxyWithOev](https://seitrace.com/address/0x18d6F2b16729F2B06eBa584B3Cd9B30771Ceb5c7)
[DapiProxyWithOev](https://seitrace.com/address/0x62AbEfcFD9451364E4Eb8bC7aEF9540378e3Eb3c)
[Api3Market](https://seitrace.com/address/0xE20544835208AA8aDa06BCEb666a5630dE4dAF7C)

**taiko - [bridge](https://bridge.taiko.xyz) - [docs](https://docs.taiko.xyz/guides/app-developers/set-up-your-wallet/)**
---
Taiko does not allow legacy transaction, thus deterministic deployment is not available. Contract verification API may fail on some occasions while fetching contract code. There are [multiple](https://docs.taiko.xyz/network-reference/rpc-configuration) block explorers available [blockscout](https://blockscoutapi.mainnet.taiko.xyz) and [etherscan](https://taikoscan.io/address/0xbbca0709c54cd137145aab34c02754f582b94b08). Blockscout can verify all the contracts while etherscan fail on ProxyContracts

[OwnableCallForwarder](https://taikoscan.io/address/0xbf660585eFb7F31F68bB3375937b7C71376de6c8)
[Api3ServerV1](https://taikoscan.io/address/0x1B127098D19A3D6A0417560fD7df2b927FafD933)
[Api3Market](https://taikoscan.io/address/0x83B1FE7E5708d5Bd3836dE3ae83e5A2c1b92850c)

