### PR TITLE
Temporarily change the default Taiko RPC until the official one is fixed

### DIFF
--- a/.changeset/nice-needles-yell.md
+++ b/.changeset/nice-needles-yell.md
@@ -1,0 +1,5 @@
+---
+"@api3/chains": patch
+---
+
+Temporarily change the default Taiko RPC until the official one is fixed

--- a/chains/taiko.json
+++ b/chains/taiko.json
@@ -15,7 +15,7 @@
   "providers": [
     {
       "alias": "default",
-      "rpcUrl": "https://rpc.taiko.xyz"
+      "rpcUrl": "https://rpc.taiko.tools"
     },
     {
       "alias": "drpc",

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -1390,7 +1390,7 @@ export const CHAINS: Chain[] = [
     id: '167000',
     name: 'Taiko',
     providers: [
-      { alias: 'default', rpcUrl: 'https://rpc.taiko.xyz' },
+      { alias: 'default', rpcUrl: 'https://rpc.taiko.tools' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
     ],
     symbol: 'ETH',


### PR DESCRIPTION
Rushing this so that it's in the next Dint deployment