### PR TITLE
Add providers for several chains

### DIFF
--- a/.changeset/seven-donkeys-explode.md
+++ b/.changeset/seven-donkeys-explode.md
@@ -1,0 +1,19 @@
+---
+'@api3/chains': patch
+---
+
+Add providers for the following chains: 
+
+* astar
+* bob
+* bsquared
+* core
+* kava
+* kroma
+* mantle
+* merlin
+* metis
+* mode
+* opbnb
+* taiko
+* x-layer

--- a/.changeset/seven-donkeys-explode.md
+++ b/.changeset/seven-donkeys-explode.md
@@ -11,7 +11,6 @@ Add providers for the following chains:
 * kava
 * kroma
 * mantle
-* merlin
 * metis
 * mode
 * opbnb

--- a/chains/astar.json
+++ b/chains/astar.json
@@ -20,6 +20,10 @@
     {
       "alias": "dwellir",
       "homepageUrl": "https://dwellir.com/"
+    },
+    {
+      "alias": "gelato",
+      "rpcUrl": "https://rpc.astar-zkevm.gelato.digital"
     }
   ],
   "symbol": "ETH",

--- a/chains/bob.json
+++ b/chains/bob.json
@@ -16,6 +16,14 @@
     {
       "alias": "default",
       "rpcUrl": "https://rpc.gobob.xyz/"
+    },
+    {
+      "alias": "blastapi",
+      "homepageUrl": "https://blastapi.io"
+    },
+    {
+      "alias": "tenderly",
+      "homepageUrl": "https://tenderly.co/"
     }
   ],
   "symbol": "ETH",

--- a/chains/bsquared.json
+++ b/chains/bsquared.json
@@ -18,6 +18,10 @@
       "rpcUrl": "https://rpc.bsquared.network"
     },
     {
+      "alias": "ankr",
+      "homepageUrl": "https://ankr.com"
+    },
+    {
       "alias": "public",
       "rpcUrl": "https://b2-mainnet.alt.technology"
     }

--- a/chains/core.json
+++ b/chains/core.json
@@ -18,6 +18,14 @@
       "rpcUrl": "https://rpc.coredao.org/"
     },
     {
+      "alias": "1rpc",
+      "homepageUrl": "https://1rpc.io/"
+    },
+    {
+      "alias": "ankr",
+      "homepageUrl": "https://ankr.com"
+    },
+    {
       "alias": "drpc",
       "homepageUrl": "https://drpc.org"
     }

--- a/chains/kava.json
+++ b/chains/kava.json
@@ -18,6 +18,10 @@
       "rpcUrl": "https://evm.kava.io/"
     },
     {
+      "alias": "ankr",
+      "homepageUrl": "https://ankr.com"
+    },
+    {
       "alias": "drpc",
       "homepageUrl": "https://drpc.org/"
     },

--- a/chains/kroma.json
+++ b/chains/kroma.json
@@ -16,6 +16,14 @@
     {
       "alias": "default",
       "rpcUrl": "https://api.kroma.network/"
+    },
+    {
+      "alias": "1rpc",
+      "homepageUrl": "https://1rpc.io/"
+    },
+    {
+      "alias": "rockx",
+      "homepageUrl": "https://rockx.com/"
     }
   ],
   "symbol": "ETH",

--- a/chains/mantle.json
+++ b/chains/mantle.json
@@ -28,6 +28,10 @@
     {
       "alias": "reblok",
       "homepageUrl": "https://reblok.io"
+    },
+    {
+      "alias": "quicknode",
+      "homepageUrl": "https://quicknode.com"
     }
   ],
   "symbol": "MNT",

--- a/chains/merlin.json
+++ b/chains/merlin.json
@@ -20,10 +20,6 @@
     {
       "alias": "blockpi",
       "homepageUrl": "https://blockpi.io"
-    },
-    {
-      "alias": "rockx",
-      "homepageUrl": "https://rockx.com/"
     }
   ],
   "symbol": "BTC",

--- a/chains/merlin.json
+++ b/chains/merlin.json
@@ -20,6 +20,10 @@
     {
       "alias": "blockpi",
       "homepageUrl": "https://blockpi.io"
+    },
+    {
+      "alias": "rockx",
+      "homepageUrl": "https://rockx.com/"
     }
   ],
   "symbol": "BTC",

--- a/chains/metis.json
+++ b/chains/metis.json
@@ -24,6 +24,10 @@
     {
       "alias": "drpc",
       "homepageUrl": "https://drpc.org"
+    },
+    {
+      "alias": "grove",
+      "homepageUrl": "https://grove.city/"
     }
   ],
   "symbol": "METIS",

--- a/chains/mode.json
+++ b/chains/mode.json
@@ -18,6 +18,10 @@
       "rpcUrl": "https://mainnet.mode.network"
     },
     {
+      "alias": "1rpc",
+      "homepageUrl": "https://1rpc.io/"
+    },
+    {
       "alias": "blastapi",
       "homepageUrl": "https://blastapi.io"
     },

--- a/chains/opbnb.json
+++ b/chains/opbnb.json
@@ -18,12 +18,16 @@
       "rpcUrl": "https://opbnb-mainnet-rpc.bnbchain.org"
     },
     {
-      "alias": "publicnode",
-      "rpcUrl": "https://opbnb-rpc.publicnode.com"
+      "alias": "blastapi",
+      "homepageUrl": "https://blastapi.io"
     },
     {
-      "alias": "drpc-freemium",
-      "rpcUrl": "https://lb.drpc.org/ogrpc?network=opbnb&dkey=AiPHJac9aUX2s7ELd131NuwSeHqkUW8R7oQiFnomaLKw"
+      "alias": "drpc",
+      "homepageUrl": "https://drpc.org/"
+    },
+    {
+      "alias": "publicnode",
+      "rpcUrl": "https://opbnb-rpc.publicnode.com"
     }
   ],
   "symbol": "BNB",

--- a/chains/taiko.json
+++ b/chains/taiko.json
@@ -18,6 +18,14 @@
       "rpcUrl": "https://rpc.taiko.tools"
     },
     {
+      "alias": "ankr",
+      "homepageUrl": "https://ankr.com"
+    },
+    {
+      "alias": "blockpi",
+      "homepageUrl": "https://blockpi.io"
+    },
+    {
       "alias": "drpc",
       "homepageUrl": "https://drpc.org"
     }

--- a/chains/x-layer.json
+++ b/chains/x-layer.json
@@ -12,6 +12,10 @@
       "rpcUrl": "https://rpc.xlayer.tech/"
     },
     {
+      "alias": "ankr",
+      "homepageUrl": "https://ankr.com"
+    },
+    {
       "alias": "okx",
       "rpcUrl": "https://xlayerrpc.okx.com/"
     }

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -100,6 +100,7 @@ export const CHAINS: Chain[] = [
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc.startale.com/astar-zkevm' },
       { alias: 'dwellir', homepageUrl: 'https://dwellir.com/' },
+      { alias: 'gelato', rpcUrl: 'https://rpc.astar-zkevm.gelato.digital' },
     ],
     symbol: 'ETH',
     testnet: false,
@@ -286,7 +287,11 @@ export const CHAINS: Chain[] = [
     },
     id: '60808',
     name: 'BOB',
-    providers: [{ alias: 'default', rpcUrl: 'https://rpc.gobob.xyz/' }],
+    providers: [
+      { alias: 'default', rpcUrl: 'https://rpc.gobob.xyz/' },
+      { alias: 'blastapi', homepageUrl: 'https://blastapi.io' },
+      { alias: 'tenderly', homepageUrl: 'https://tenderly.co/' },
+    ],
     symbol: 'ETH',
     testnet: false,
   },
@@ -373,6 +378,7 @@ export const CHAINS: Chain[] = [
     name: 'BSquared Network',
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc.bsquared.network' },
+      { alias: 'ankr', homepageUrl: 'https://ankr.com' },
       { alias: 'public', rpcUrl: 'https://b2-mainnet.alt.technology' },
     ],
     symbol: 'BTC',
@@ -432,6 +438,8 @@ export const CHAINS: Chain[] = [
     name: 'Core',
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc.coredao.org/' },
+      { alias: '1rpc', homepageUrl: 'https://1rpc.io/' },
+      { alias: 'ankr', homepageUrl: 'https://ankr.com' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
     ],
     symbol: 'CORE',
@@ -697,6 +705,7 @@ export const CHAINS: Chain[] = [
     name: 'Kava',
     providers: [
       { alias: 'default', rpcUrl: 'https://evm.kava.io/' },
+      { alias: 'ankr', homepageUrl: 'https://ankr.com' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org/' },
       { alias: 'nodies', homepageUrl: 'https://nodies.app/' },
       { alias: 'reblok', homepageUrl: 'https://reblok.io' },
@@ -726,7 +735,11 @@ export const CHAINS: Chain[] = [
     },
     id: '255',
     name: 'Kroma',
-    providers: [{ alias: 'default', rpcUrl: 'https://api.kroma.network/' }],
+    providers: [
+      { alias: 'default', rpcUrl: 'https://api.kroma.network/' },
+      { alias: '1rpc', homepageUrl: 'https://1rpc.io/' },
+      { alias: 'rockx', homepageUrl: 'https://rockx.com/' },
+    ],
     symbol: 'ETH',
     testnet: false,
   },
@@ -847,6 +860,7 @@ export const CHAINS: Chain[] = [
       { alias: 'blastapi', homepageUrl: 'https://blastapi.io' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org/' },
       { alias: 'reblok', homepageUrl: 'https://reblok.io' },
+      { alias: 'quicknode', homepageUrl: 'https://quicknode.com' },
     ],
     symbol: 'MNT',
     testnet: false,
@@ -896,6 +910,7 @@ export const CHAINS: Chain[] = [
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc.merlinchain.io' },
       { alias: 'blockpi', homepageUrl: 'https://blockpi.io' },
+      { alias: 'rockx', homepageUrl: 'https://rockx.com/' },
     ],
     symbol: 'BTC',
     testnet: false,
@@ -962,6 +977,7 @@ export const CHAINS: Chain[] = [
       { alias: 'default', rpcUrl: 'https://andromeda.metis.io/?owner=1088' },
       { alias: 'blastapi', homepageUrl: 'https://blastapi.io' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
+      { alias: 'grove', homepageUrl: 'https://grove.city/' },
     ],
     symbol: 'METIS',
     testnet: false,
@@ -1016,6 +1032,7 @@ export const CHAINS: Chain[] = [
     name: 'Mode',
     providers: [
       { alias: 'default', rpcUrl: 'https://mainnet.mode.network' },
+      { alias: '1rpc', homepageUrl: 'https://1rpc.io/' },
       { alias: 'blastapi', homepageUrl: 'https://blastapi.io' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org/' },
     ],
@@ -1152,11 +1169,9 @@ export const CHAINS: Chain[] = [
     name: 'opBNB',
     providers: [
       { alias: 'default', rpcUrl: 'https://opbnb-mainnet-rpc.bnbchain.org' },
+      { alias: 'blastapi', homepageUrl: 'https://blastapi.io' },
+      { alias: 'drpc', homepageUrl: 'https://drpc.org/' },
       { alias: 'publicnode', rpcUrl: 'https://opbnb-rpc.publicnode.com' },
-      {
-        alias: 'drpc-freemium',
-        rpcUrl: 'https://lb.drpc.org/ogrpc?network=opbnb&dkey=AiPHJac9aUX2s7ELd131NuwSeHqkUW8R7oQiFnomaLKw',
-      },
     ],
     symbol: 'BNB',
     testnet: false,
@@ -1391,6 +1406,8 @@ export const CHAINS: Chain[] = [
     name: 'Taiko',
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc.taiko.tools' },
+      { alias: 'ankr', homepageUrl: 'https://ankr.com' },
+      { alias: 'blockpi', homepageUrl: 'https://blockpi.io' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
     ],
     symbol: 'ETH',
@@ -1417,6 +1434,7 @@ export const CHAINS: Chain[] = [
     name: 'X Layer',
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc.xlayer.tech/' },
+      { alias: 'ankr', homepageUrl: 'https://ankr.com' },
       { alias: 'okx', rpcUrl: 'https://xlayerrpc.okx.com/' },
     ],
     symbol: 'OKB',

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -910,7 +910,6 @@ export const CHAINS: Chain[] = [
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc.merlinchain.io' },
       { alias: 'blockpi', homepageUrl: 'https://blockpi.io' },
-      { alias: 'rockx', homepageUrl: 'https://rockx.com/' },
     ],
     symbol: 'BTC',
     testnet: false,


### PR DESCRIPTION
I revisited RPC provider supports for the recently integrated chains. For this end, new subscriptions have been bought for `1rpc`, `ankr` and `rockx`.