### PR TITLE
Update name of blast-sepolia-testnet

### DIFF
--- a/.changeset/tall-avocados-suffer.md
+++ b/.changeset/tall-avocados-suffer.md
@@ -1,0 +1,5 @@
+---
+'@api3/chains': patch
+---
+
+Update name of blast-sepolia-testnet

--- a/chains/blast-sepolia-testnet.json
+++ b/chains/blast-sepolia-testnet.json
@@ -11,7 +11,7 @@
     "browserUrl": "https://sepolia.blastscan.io/"
   },
   "id": "168587773",
-  "name": "Blast Testnet",
+  "name": "Blast testnet",
   "providers": [
     {
       "alias": "default",

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -269,7 +269,7 @@ export const CHAINS: Chain[] = [
       browserUrl: 'https://sepolia.blastscan.io/',
     },
     id: '168587773',
-    name: 'Blast Testnet',
+    name: 'Blast testnet',
     providers: [
       { alias: 'default', rpcUrl: 'https://sepolia.blast.io' },
       {


### PR DESCRIPTION
As convention says, `-testnet` should be lower-cased. 