### PR TITLE
Update providers for taiko

### DIFF
--- a/.changeset/popular-poems-refuse.md
+++ b/.changeset/popular-poems-refuse.md
@@ -2,4 +2,5 @@
 '@api3/chains': patch
 ---
 
-Add official public provider for taiko
+* Add official public provider for taiko
+* Remove blockpi from taiko due to excessive gas price

--- a/.changeset/popular-poems-refuse.md
+++ b/.changeset/popular-poems-refuse.md
@@ -1,0 +1,5 @@
+---
+'@api3/chains': patch
+---
+
+Add official public provider for taiko

--- a/chains/taiko.json
+++ b/chains/taiko.json
@@ -18,6 +18,10 @@
       "rpcUrl": "https://rpc.taiko.tools"
     },
     {
+      "alias": "public",
+      "rpcUrl": "https://rpc.mainnet.taiko.xyz"
+    },
+    {
       "alias": "ankr",
       "homepageUrl": "https://ankr.com"
     },

--- a/chains/taiko.json
+++ b/chains/taiko.json
@@ -26,10 +26,6 @@
       "homepageUrl": "https://ankr.com"
     },
     {
-      "alias": "blockpi",
-      "homepageUrl": "https://blockpi.io"
-    },
-    {
       "alias": "drpc",
       "homepageUrl": "https://drpc.org"
     }

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -1477,6 +1477,7 @@ export const CHAINS: Chain[] = [
     name: 'Taiko',
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc.taiko.tools' },
+      { alias: 'public', rpcUrl: 'https://rpc.mainnet.taiko.xyz' },
       { alias: 'ankr', homepageUrl: 'https://ankr.com' },
       { alias: 'blockpi', homepageUrl: 'https://blockpi.io' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -1479,7 +1479,6 @@ export const CHAINS: Chain[] = [
       { alias: 'default', rpcUrl: 'https://rpc.taiko.tools' },
       { alias: 'public', rpcUrl: 'https://rpc.mainnet.taiko.xyz' },
       { alias: 'ankr', homepageUrl: 'https://ankr.com' },
-      { alias: 'blockpi', homepageUrl: 'https://blockpi.io' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
     ],
     symbol: 'ETH',


### PR DESCRIPTION
- Provider maintained by Taiko Labs has been added.
- Provider `blockpi` has been removed because it returns gas price more than 1000x (eth_gasPrice) and causes overpriced transactions. One can see [here](https://monitor.reblok.io/d/GsfMlsc4k/rpc-watcher?orgId=1&var-chain=taiko&var-provider=All&var-published=All&from=1717876318573&to=1717962718573&viewPanel=46).