### PR TITLE
Remove provider 1rpc from the existing chains

### DIFF
--- a/.changeset/brown-seas-enjoy.md
+++ b/.changeset/brown-seas-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@api3/chains': patch
+---
+
+Remove provider `1rpc` from the existing chains

--- a/chains/core.json
+++ b/chains/core.json
@@ -18,10 +18,6 @@
       "rpcUrl": "https://rpc.coredao.org/"
     },
     {
-      "alias": "1rpc",
-      "homepageUrl": "https://1rpc.io/"
-    },
-    {
       "alias": "ankr",
       "homepageUrl": "https://ankr.com"
     },

--- a/chains/kroma.json
+++ b/chains/kroma.json
@@ -18,10 +18,6 @@
       "rpcUrl": "https://api.kroma.network/"
     },
     {
-      "alias": "1rpc",
-      "homepageUrl": "https://1rpc.io/"
-    },
-    {
       "alias": "rockx",
       "homepageUrl": "https://rockx.com/"
     }

--- a/chains/mode.json
+++ b/chains/mode.json
@@ -18,10 +18,6 @@
       "rpcUrl": "https://mainnet.mode.network"
     },
     {
-      "alias": "1rpc",
-      "homepageUrl": "https://1rpc.io/"
-    },
-    {
       "alias": "blastapi",
       "homepageUrl": "https://blastapi.io"
     },

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -472,7 +472,6 @@ export const CHAINS: Chain[] = [
     name: 'Core',
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc.coredao.org/' },
-      { alias: '1rpc', homepageUrl: 'https://1rpc.io/' },
       { alias: 'ankr', homepageUrl: 'https://ankr.com' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
     ],
@@ -771,7 +770,6 @@ export const CHAINS: Chain[] = [
     name: 'Kroma',
     providers: [
       { alias: 'default', rpcUrl: 'https://api.kroma.network/' },
-      { alias: '1rpc', homepageUrl: 'https://1rpc.io/' },
       { alias: 'rockx', homepageUrl: 'https://rockx.com/' },
     ],
     symbol: 'ETH',
@@ -1065,7 +1063,6 @@ export const CHAINS: Chain[] = [
     name: 'Mode',
     providers: [
       { alias: 'default', rpcUrl: 'https://mainnet.mode.network' },
-      { alias: '1rpc', homepageUrl: 'https://1rpc.io/' },
       { alias: 'blastapi', homepageUrl: 'https://blastapi.io' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org/' },
     ],


### PR DESCRIPTION
This is technically unreliable provider with high response latency and lots of down-time. It will be better to not have. 