### PR TITLE
Update default provider for ethereum

### DIFF
--- a/.changeset/tasty-jars-punch.md
+++ b/.changeset/tasty-jars-punch.md
@@ -1,0 +1,5 @@
+---
+'@api3/chains': patch
+---
+
+Update default provider for etheruem

--- a/chains/ethereum.json
+++ b/chains/ethereum.json
@@ -16,7 +16,7 @@
   "providers": [
     {
       "alias": "default",
-      "rpcUrl": "https://cloudflare-eth.com"
+      "rpcUrl": "https://ethereum-rpc.publicnode.com"
     },
     {
       "alias": "blastapi",

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -537,7 +537,7 @@ export const CHAINS: Chain[] = [
     id: '1',
     name: 'Ethereum',
     providers: [
-      { alias: 'default', rpcUrl: 'https://cloudflare-eth.com' },
+      { alias: 'default', rpcUrl: 'https://ethereum-rpc.publicnode.com' },
       { alias: 'blastapi', homepageUrl: 'https://blastapi.io' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
       { alias: 'quicknode', homepageUrl: 'https://quicknode.com' },


### PR DESCRIPTION
Response time of the current default provider is on higher side. So I'm proposing to switch better alternative.