### PR TITLE
Do not check for changesets on push to main

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -56,6 +56,7 @@ jobs:
 
   require-changeset:
     runs-on: ubuntu-latest
+    if: github.actor != 'renovate[bot]' && github.ref != 'refs/heads/main'
     steps:
       - name: Clone @api3/chains
         uses: actions/checkout@v4
@@ -65,7 +66,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 9
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -77,7 +78,6 @@ jobs:
         run: pnpm install
 
       - name: Check for changeset
-        if: github.actor != 'renovate[bot]'
         run: pnpm changeset status --since=origin/main
 
   required-checks-passed:


### PR DESCRIPTION
Closes #374. The alternative would be to move the changeset check to a separate file, but I don't feel that's necessary