### PR TITLE
Remove inconsistent providers from manta and zircuit

### DIFF
--- a/.changeset/clean-windows-move.md
+++ b/.changeset/clean-windows-move.md
@@ -1,0 +1,5 @@
+---
+"@api3/chains": patch
+---
+
+Remove inconsistent RPCs from manta and zircuit chains

--- a/chains/manta.json
+++ b/chains/manta.json
@@ -15,19 +15,11 @@
   "providers": [
     {
       "alias": "default",
-      "rpcUrl": "https://pacific-rpc.manta.network/http"
-    },
-    {
-      "alias": "public",
       "rpcUrl": "https://r1.pacific.manta.systems/http"
     },
     {
       "alias": "nirvanalabs",
       "rpcUrl": "https://manta.nirvanalabs.xyz/mantapublic"
-    },
-    {
-      "alias": "tencentcloud",
-      "rpcUrl": "https://www.tencentcloud-rpc.com/v2/manta/manta-rpc"
     },
     {
       "alias": "drpc",

--- a/chains/zircuit.json
+++ b/chains/zircuit.json
@@ -12,10 +12,6 @@
       "rpcUrl": "https://zircuit1-mainnet.p2pify.com/"
     },
     {
-      "alias": "liquify",
-      "rpcUrl": "https://zircuit1-mainnet.liquify.com"
-    },
-    {
       "alias": "drpc",
       "homepageUrl": "https://drpc.org"
     }

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -920,10 +920,8 @@ export const CHAINS: Chain[] = [
     id: '169',
     name: 'Manta',
     providers: [
-      { alias: 'default', rpcUrl: 'https://pacific-rpc.manta.network/http' },
-      { alias: 'public', rpcUrl: 'https://r1.pacific.manta.systems/http' },
+      { alias: 'default', rpcUrl: 'https://r1.pacific.manta.systems/http' },
       { alias: 'nirvanalabs', rpcUrl: 'https://manta.nirvanalabs.xyz/mantapublic' },
-      { alias: 'tencentcloud', rpcUrl: 'https://www.tencentcloud-rpc.com/v2/manta/manta-rpc' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
     ],
     symbol: 'ETH',
@@ -1590,7 +1588,6 @@ export const CHAINS: Chain[] = [
     name: 'Zircuit',
     providers: [
       { alias: 'default', rpcUrl: 'https://zircuit1-mainnet.p2pify.com/' },
-      { alias: 'liquify', rpcUrl: 'https://zircuit1-mainnet.liquify.com' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
     ],
     symbol: 'ETH',


### PR DESCRIPTION
Closes #405 

`public` RPC for `manta` renamed to `default` as its mandatory to poses a provider called `default`