### PR TITLE
Add sonic-testnet for CSUR

### DIFF
--- a/.changeset/empty-pandas-sip.md
+++ b/.changeset/empty-pandas-sip.md
@@ -1,0 +1,6 @@
+---
+'@api3/chains': minor
+---
+
+Adds following chain:
+* sonic-testnet

--- a/chains/sonic-testnet.json
+++ b/chains/sonic-testnet.json
@@ -1,0 +1,17 @@
+{
+  "alias": "sonic-testnet",
+  "decimals": 18,
+  "explorer": {
+    "browserUrl": "https://public-sonic.fantom.network/"
+  },
+  "id": "64165",
+  "name": "Sonic testnet",
+  "providers": [
+    {
+      "alias": "default",
+      "rpcUrl": "https://rpc.sonic.fantom.network"
+    }
+  ],
+  "symbol": "FTM",
+  "testnet": true
+}

--- a/chains/sonic-testnet.json
+++ b/chains/sonic-testnet.json
@@ -12,6 +12,6 @@
       "rpcUrl": "https://rpc.sonic.fantom.network"
     }
   ],
-  "symbol": "FTM",
+  "symbol": "S",
   "testnet": true
 }

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -1510,6 +1510,16 @@ export const CHAINS: Chain[] = [
     testnet: false,
   },
   {
+    alias: 'sonic-testnet',
+    decimals: 18,
+    explorer: { browserUrl: 'https://public-sonic.fantom.network/' },
+    id: '64165',
+    name: 'Sonic testnet',
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.sonic.fantom.network' }],
+    symbol: 'FTM',
+    testnet: true,
+  },
+  {
     alias: 'sx-testnet',
     decimals: 18,
     explorer: {

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -1516,7 +1516,7 @@ export const CHAINS: Chain[] = [
     id: '64165',
     name: 'Sonic testnet',
     providers: [{ alias: 'default', rpcUrl: 'https://rpc.sonic.fantom.network' }],
-    symbol: 'FTM',
+    symbol: 'S',
     testnet: true,
   },
   {


### PR DESCRIPTION
See: https://github.com/api3dao/tasks/issues/1395, [slack](https://api3workspace.slack.com/archives/C075C5780HJ/p1724744875672289)

This PR adds following chain:
* sonic-testnet

This chain does not have a working contract verification module, yet.