### PR TITLE
Update providers

### DIFF
--- a/.changeset/rude-cars-accept.md
+++ b/.changeset/rude-cars-accept.md
@@ -1,0 +1,5 @@
+---
+'@api3/chains': patch
+---
+
+Update providers

--- a/chains/arbitrum.json
+++ b/chains/arbitrum.json
@@ -19,6 +19,10 @@
       "rpcUrl": "https://arb1.arbitrum.io/rpc"
     },
     {
+      "alias": "publicnode",
+      "rpcUrl": "https://arbitrum-one-rpc.publicnode.com/"
+    },
+    {
       "alias": "blastapi",
       "homepageUrl": "https://blastapi.io"
     },

--- a/chains/base.json
+++ b/chains/base.json
@@ -18,6 +18,10 @@
       "rpcUrl": "https://mainnet.base.org"
     },
     {
+      "alias": "publicnode",
+      "rpcUrl": "https://base-rpc.publicnode.com/"
+    },
+    {
       "alias": "blastapi",
       "homepageUrl": "https://blastapi.io"
     },

--- a/chains/bob.json
+++ b/chains/bob.json
@@ -22,6 +22,10 @@
       "homepageUrl": "https://blastapi.io"
     },
     {
+      "alias": "drpc",
+      "homepageUrl": "https://drpc.org"
+    },
+    {
       "alias": "tenderly",
       "homepageUrl": "https://tenderly.co/"
     }

--- a/chains/bsquared.json
+++ b/chains/bsquared.json
@@ -18,10 +18,6 @@
       "rpcUrl": "https://rpc.bsquared.network"
     },
     {
-      "alias": "ankr",
-      "homepageUrl": "https://ankr.com"
-    },
-    {
       "alias": "public",
       "rpcUrl": "https://b2-mainnet.alt.technology"
     }

--- a/chains/conflux.json
+++ b/chains/conflux.json
@@ -24,6 +24,10 @@
     {
       "alias": "backup",
       "rpcUrl": "https://evm.confluxrpc.org/"
+    },
+    {
+      "alias": "blockpi",
+      "homepageUrl": "https://blockpi.io"
     }
   ],
   "symbol": "CFX",

--- a/chains/core.json
+++ b/chains/core.json
@@ -18,6 +18,10 @@
       "rpcUrl": "https://rpc.coredao.org/"
     },
     {
+      "alias": "icecreamswap",
+      "rpcUrl": "https://rpc-core.icecreamswap.com/"
+    },
+    {
       "alias": "ankr",
       "homepageUrl": "https://ankr.com"
     },

--- a/chains/fantom.json
+++ b/chains/fantom.json
@@ -19,6 +19,10 @@
       "rpcUrl": "https://rpc3.fantom.network/"
     },
     {
+      "alias": "publicnode",
+      "rpcUrl": "https://fantom-rpc.publicnode.com/"
+    },
+    {
       "alias": "blastapi",
       "homepageUrl": "https://blastapi.io"
     },

--- a/chains/fraxtal.json
+++ b/chains/fraxtal.json
@@ -18,12 +18,16 @@
       "rpcUrl": "https://rpc.frax.com"
     },
     {
-      "alias": "tenderly",
-      "homepageUrl": "https://tenderly.co/"
+      "alias": "drpc",
+      "homepageUrl": "https://drpc.org"
     },
     {
       "alias": "grove",
       "homepageUrl": "https://grove.city/"
+    },
+    {
+      "alias": "tenderly",
+      "homepageUrl": "https://tenderly.co/"
     }
   ],
   "symbol": "ETH",

--- a/chains/gnosis.json
+++ b/chains/gnosis.json
@@ -19,6 +19,10 @@
       "rpcUrl": "https://rpc.gnosischain.com"
     },
     {
+      "alias": "publicnode",
+      "rpcUrl": "https://gnosis-rpc.publicnode.com/"
+    },
+    {
       "alias": "blastapi",
       "homepageUrl": "https://blastapi.io"
     },

--- a/chains/kava-testnet.json
+++ b/chains/kava-testnet.json
@@ -16,10 +16,6 @@
     {
       "alias": "default",
       "rpcUrl": "https://evm.testnet.kava.io/"
-    },
-    {
-      "alias": "drpc-freemium",
-      "rpcUrl": "https://lb.drpc.org/ogrpc?network=kava-testnet&dkey=AiPHJac9aUX2s7ELd131NuwSeHqkUW8R7oQiFnomaLKw"
     }
   ],
   "symbol": "KAVA",

--- a/chains/kava.json
+++ b/chains/kava.json
@@ -18,6 +18,10 @@
       "rpcUrl": "https://evm.kava.io/"
     },
     {
+      "alias": "publicnode",
+      "rpcUrl": "https://kava-evm-rpc.publicnode.com/"
+    },
+    {
       "alias": "ankr",
       "homepageUrl": "https://ankr.com"
     },

--- a/chains/kroma.json
+++ b/chains/kroma.json
@@ -18,6 +18,10 @@
       "rpcUrl": "https://api.kroma.network/"
     },
     {
+      "alias": "drpc",
+      "homepageUrl": "https://drpc.org"
+    },
+    {
       "alias": "rockx",
       "homepageUrl": "https://rockx.com/"
     }

--- a/chains/linea.json
+++ b/chains/linea.json
@@ -26,6 +26,10 @@
       "homepageUrl": "https://drpc.org/"
     },
     {
+      "alias": "quicknode",
+      "homepageUrl": "https://quicknode.com"
+    },
+    {
       "alias": "reblok",
       "homepageUrl": "https://reblok.io"
     }

--- a/chains/lukso.json
+++ b/chains/lukso.json
@@ -16,6 +16,10 @@
     {
       "alias": "default",
       "rpcUrl": "https://rpc.mainnet.lukso.network"
+    },
+    {
+      "alias": "sigmacore",
+      "rpcUrl": "https://rpc.lukso.sigmacore.io/"
     }
   ],
   "symbol": "LYX",

--- a/chains/manta.json
+++ b/chains/manta.json
@@ -15,6 +15,10 @@
   "providers": [
     {
       "alias": "default",
+      "rpcUrl": "https://pacific-rpc.manta.network/http"
+    },
+    {
+      "alias": "public",
       "rpcUrl": "https://r1.pacific.manta.systems/http"
     },
     {

--- a/chains/metal.json
+++ b/chains/metal.json
@@ -16,6 +16,10 @@
     {
       "alias": "default",
       "rpcUrl": "https://rpc.metall2.com/"
+    },
+    {
+      "alias": "drpc",
+      "homepageUrl": "https://drpc.org"
     }
   ],
   "symbol": "ETH",

--- a/chains/metis.json
+++ b/chains/metis.json
@@ -18,6 +18,10 @@
       "rpcUrl": "https://andromeda.metis.io/?owner=1088"
     },
     {
+      "alias": "ankr",
+      "homepageUrl": "https://ankr.com"
+    },
+    {
       "alias": "blastapi",
       "homepageUrl": "https://blastapi.io"
     },

--- a/chains/moonbeam.json
+++ b/chains/moonbeam.json
@@ -19,6 +19,10 @@
       "rpcUrl": "https://rpc.api.moonbeam.network"
     },
     {
+      "alias": "ankr",
+      "homepageUrl": "https://ankr.com"
+    },
+    {
       "alias": "publicnode",
       "rpcUrl": "https://moonbeam-rpc.publicnode.com"
     },

--- a/chains/neon-evm.json
+++ b/chains/neon-evm.json
@@ -18,8 +18,8 @@
       "rpcUrl": "https://neon-proxy-mainnet.solana.p2p.org"
     },
     {
-      "alias": "drpc",
-      "homepageUrl": "https://drpc.org"
+      "alias": "everstake",
+      "rpcUrl": "https://neon-mainnet.everstake.one"
     }
   ],
   "symbol": "NEON",

--- a/chains/opbnb.json
+++ b/chains/opbnb.json
@@ -18,16 +18,16 @@
       "rpcUrl": "https://opbnb-mainnet-rpc.bnbchain.org"
     },
     {
+      "alias": "publicnode",
+      "rpcUrl": "https://opbnb-rpc.publicnode.com"
+    },
+    {
       "alias": "blastapi",
       "homepageUrl": "https://blastapi.io"
     },
     {
       "alias": "drpc",
       "homepageUrl": "https://drpc.org/"
-    },
-    {
-      "alias": "publicnode",
-      "rpcUrl": "https://opbnb-rpc.publicnode.com"
     }
   ],
   "symbol": "BNB",

--- a/chains/optimism.json
+++ b/chains/optimism.json
@@ -19,6 +19,10 @@
       "rpcUrl": "https://mainnet.optimism.io"
     },
     {
+      "alias": "publicnode",
+      "rpcUrl": "https://optimism-rpc.publicnode.com/"
+    },
+    {
       "alias": "blastapi",
       "homepageUrl": "https://blastapi.io"
     },

--- a/chains/scroll-sepolia-testnet.json
+++ b/chains/scroll-sepolia-testnet.json
@@ -16,10 +16,6 @@
     {
       "alias": "default",
       "rpcUrl": "https://sepolia-rpc.scroll.io"
-    },
-    {
-      "alias": "drpc-freemium",
-      "rpcUrl": "https://lb.drpc.org/ogrpc?network=scroll-sepolia&dkey=AiPHJac9aUX2s7ELd131NuwSeHqkUW8R7oQiFnomaLKw"
     }
   ],
   "symbol": "ETH",

--- a/chains/zircuit.json
+++ b/chains/zircuit.json
@@ -12,6 +12,10 @@
       "rpcUrl": "https://zircuit1-mainnet.p2pify.com/"
     },
     {
+      "alias": "public",
+      "rpcUrl": "https://zircuit1-mainnet.liquify.com"
+    },
+    {
       "alias": "drpc",
       "homepageUrl": "https://drpc.org"
     }

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -64,6 +64,7 @@ export const CHAINS: Chain[] = [
     name: 'Arbitrum One',
     providers: [
       { alias: 'default', rpcUrl: 'https://arb1.arbitrum.io/rpc' },
+      { alias: 'publicnode', rpcUrl: 'https://arbitrum-one-rpc.publicnode.com/' },
       { alias: 'blastapi', homepageUrl: 'https://blastapi.io' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
       { alias: 'quicknode', homepageUrl: 'https://quicknode.com' },
@@ -204,6 +205,7 @@ export const CHAINS: Chain[] = [
     name: 'Base',
     providers: [
       { alias: 'default', rpcUrl: 'https://mainnet.base.org' },
+      { alias: 'publicnode', rpcUrl: 'https://base-rpc.publicnode.com/' },
       { alias: 'blastapi', homepageUrl: 'https://blastapi.io' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
       { alias: 'quicknode', homepageUrl: 'https://quicknode.com' },
@@ -321,6 +323,7 @@ export const CHAINS: Chain[] = [
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc.gobob.xyz/' },
       { alias: 'blastapi', homepageUrl: 'https://blastapi.io' },
+      { alias: 'drpc', homepageUrl: 'https://drpc.org' },
       { alias: 'tenderly', homepageUrl: 'https://tenderly.co/' },
     ],
     symbol: 'ETH',
@@ -408,7 +411,6 @@ export const CHAINS: Chain[] = [
     name: 'BSquared Network',
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc.bsquared.network' },
-      { alias: 'ankr', homepageUrl: 'https://ankr.com' },
       { alias: 'public', rpcUrl: 'https://b2-mainnet.alt.technology' },
     ],
     symbol: 'BTC',
@@ -487,6 +489,7 @@ export const CHAINS: Chain[] = [
       { alias: 'default', rpcUrl: 'https://evm.confluxrpc.com/' },
       { alias: 'public', rpcUrl: 'https://evmmain-global.confluxrpc.com/' },
       { alias: 'backup', rpcUrl: 'https://evm.confluxrpc.org/' },
+      { alias: 'blockpi', homepageUrl: 'https://blockpi.io' },
     ],
     symbol: 'CFX',
     testnet: false,
@@ -515,6 +518,7 @@ export const CHAINS: Chain[] = [
     name: 'Core',
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc.coredao.org/' },
+      { alias: 'icecreamswap', rpcUrl: 'https://rpc-core.icecreamswap.com/' },
       { alias: 'ankr', homepageUrl: 'https://ankr.com' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
     ],
@@ -615,6 +619,7 @@ export const CHAINS: Chain[] = [
     name: 'Fantom',
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc3.fantom.network/' },
+      { alias: 'publicnode', rpcUrl: 'https://fantom-rpc.publicnode.com/' },
       { alias: 'blastapi', homepageUrl: 'https://blastapi.io' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
       { alias: 'quicknode', homepageUrl: 'https://quicknode.com' },
@@ -646,8 +651,9 @@ export const CHAINS: Chain[] = [
     name: 'Fraxtal',
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc.frax.com' },
-      { alias: 'tenderly', homepageUrl: 'https://tenderly.co/' },
+      { alias: 'drpc', homepageUrl: 'https://drpc.org' },
       { alias: 'grove', homepageUrl: 'https://grove.city/' },
+      { alias: 'tenderly', homepageUrl: 'https://tenderly.co/' },
     ],
     symbol: 'ETH',
     testnet: false,
@@ -682,6 +688,7 @@ export const CHAINS: Chain[] = [
     name: 'Gnosis Chain',
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc.gnosischain.com' },
+      { alias: 'publicnode', rpcUrl: 'https://gnosis-rpc.publicnode.com/' },
       { alias: 'blastapi', homepageUrl: 'https://blastapi.io' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
       { alias: 'quicknode', homepageUrl: 'https://quicknode.com' },
@@ -757,13 +764,7 @@ export const CHAINS: Chain[] = [
     },
     id: '2221',
     name: 'Kava testnet',
-    providers: [
-      { alias: 'default', rpcUrl: 'https://evm.testnet.kava.io/' },
-      {
-        alias: 'drpc-freemium',
-        rpcUrl: 'https://lb.drpc.org/ogrpc?network=kava-testnet&dkey=AiPHJac9aUX2s7ELd131NuwSeHqkUW8R7oQiFnomaLKw',
-      },
-    ],
+    providers: [{ alias: 'default', rpcUrl: 'https://evm.testnet.kava.io/' }],
     symbol: 'KAVA',
     testnet: true,
   },
@@ -778,6 +779,7 @@ export const CHAINS: Chain[] = [
     name: 'Kava',
     providers: [
       { alias: 'default', rpcUrl: 'https://evm.kava.io/' },
+      { alias: 'publicnode', rpcUrl: 'https://kava-evm-rpc.publicnode.com/' },
       { alias: 'ankr', homepageUrl: 'https://ankr.com' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org/' },
       { alias: 'nodies', homepageUrl: 'https://nodies.app/' },
@@ -809,6 +811,7 @@ export const CHAINS: Chain[] = [
     name: 'Kroma',
     providers: [
       { alias: 'default', rpcUrl: 'https://api.kroma.network/' },
+      { alias: 'drpc', homepageUrl: 'https://drpc.org' },
       { alias: 'rockx', homepageUrl: 'https://rockx.com/' },
     ],
     symbol: 'ETH',
@@ -866,6 +869,7 @@ export const CHAINS: Chain[] = [
       { alias: 'default', rpcUrl: 'https://rpc.linea.build' },
       { alias: 'blastapi', homepageUrl: 'https://blastapi.io' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org/' },
+      { alias: 'quicknode', homepageUrl: 'https://quicknode.com' },
       { alias: 'reblok', homepageUrl: 'https://reblok.io' },
     ],
     symbol: 'ETH',
@@ -893,7 +897,10 @@ export const CHAINS: Chain[] = [
     },
     id: '42',
     name: 'Lukso',
-    providers: [{ alias: 'default', rpcUrl: 'https://rpc.mainnet.lukso.network' }],
+    providers: [
+      { alias: 'default', rpcUrl: 'https://rpc.mainnet.lukso.network' },
+      { alias: 'sigmacore', rpcUrl: 'https://rpc.lukso.sigmacore.io/' },
+    ],
     symbol: 'LYX',
     testnet: false,
   },
@@ -946,7 +953,8 @@ export const CHAINS: Chain[] = [
     id: '169',
     name: 'Manta',
     providers: [
-      { alias: 'default', rpcUrl: 'https://r1.pacific.manta.systems/http' },
+      { alias: 'default', rpcUrl: 'https://pacific-rpc.manta.network/http' },
+      { alias: 'public', rpcUrl: 'https://r1.pacific.manta.systems/http' },
       { alias: 'nirvanalabs', rpcUrl: 'https://manta.nirvanalabs.xyz/mantapublic' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
     ],
@@ -1049,7 +1057,10 @@ export const CHAINS: Chain[] = [
     },
     id: '1750',
     name: 'Metal L2',
-    providers: [{ alias: 'default', rpcUrl: 'https://rpc.metall2.com/' }],
+    providers: [
+      { alias: 'default', rpcUrl: 'https://rpc.metall2.com/' },
+      { alias: 'drpc', homepageUrl: 'https://drpc.org' },
+    ],
     symbol: 'ETH',
     testnet: false,
   },
@@ -1100,6 +1111,7 @@ export const CHAINS: Chain[] = [
     name: 'Metis',
     providers: [
       { alias: 'default', rpcUrl: 'https://andromeda.metis.io/?owner=1088' },
+      { alias: 'ankr', homepageUrl: 'https://ankr.com' },
       { alias: 'blastapi', homepageUrl: 'https://blastapi.io' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
       { alias: 'grove', homepageUrl: 'https://grove.city/' },
@@ -1196,6 +1208,7 @@ export const CHAINS: Chain[] = [
     name: 'Moonbeam',
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc.api.moonbeam.network' },
+      { alias: 'ankr', homepageUrl: 'https://ankr.com' },
       { alias: 'publicnode', rpcUrl: 'https://moonbeam-rpc.publicnode.com' },
       { alias: 'blastapi', homepageUrl: 'https://blastapi.io' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org/' },
@@ -1248,7 +1261,7 @@ export const CHAINS: Chain[] = [
     name: 'Neon EVM',
     providers: [
       { alias: 'default', rpcUrl: 'https://neon-proxy-mainnet.solana.p2p.org' },
-      { alias: 'drpc', homepageUrl: 'https://drpc.org' },
+      { alias: 'everstake', rpcUrl: 'https://neon-mainnet.everstake.one' },
     ],
     symbol: 'NEON',
     testnet: false,
@@ -1293,9 +1306,9 @@ export const CHAINS: Chain[] = [
     name: 'opBNB',
     providers: [
       { alias: 'default', rpcUrl: 'https://opbnb-mainnet-rpc.bnbchain.org' },
+      { alias: 'publicnode', rpcUrl: 'https://opbnb-rpc.publicnode.com' },
       { alias: 'blastapi', homepageUrl: 'https://blastapi.io' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org/' },
-      { alias: 'publicnode', rpcUrl: 'https://opbnb-rpc.publicnode.com' },
     ],
     symbol: 'BNB',
     testnet: false,
@@ -1330,6 +1343,7 @@ export const CHAINS: Chain[] = [
     name: 'Optimism',
     providers: [
       { alias: 'default', rpcUrl: 'https://mainnet.optimism.io' },
+      { alias: 'publicnode', rpcUrl: 'https://optimism-rpc.publicnode.com/' },
       { alias: 'blastapi', homepageUrl: 'https://blastapi.io' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
       { alias: 'quicknode', homepageUrl: 'https://quicknode.com' },
@@ -1457,13 +1471,7 @@ export const CHAINS: Chain[] = [
     },
     id: '534351',
     name: 'Scroll testnet',
-    providers: [
-      { alias: 'default', rpcUrl: 'https://sepolia-rpc.scroll.io' },
-      {
-        alias: 'drpc-freemium',
-        rpcUrl: 'https://lb.drpc.org/ogrpc?network=scroll-sepolia&dkey=AiPHJac9aUX2s7ELd131NuwSeHqkUW8R7oQiFnomaLKw',
-      },
-    ],
+    providers: [{ alias: 'default', rpcUrl: 'https://sepolia-rpc.scroll.io' }],
     symbol: 'ETH',
     testnet: true,
   },
@@ -1624,6 +1632,7 @@ export const CHAINS: Chain[] = [
     name: 'Zircuit',
     providers: [
       { alias: 'default', rpcUrl: 'https://zircuit1-mainnet.p2pify.com/' },
+      { alias: 'public', rpcUrl: 'https://zircuit1-mainnet.liquify.com' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
     ],
     symbol: 'ETH',


### PR DESCRIPTION
- I’ve found that `publicnode` performs as well as paid providers, so I’ve added it to the supported chains.
- Removed `ankr` from `bsquared` as it is no longer available in our market.
- Added `drpc` to the chains they've recently started supporting.
- Removed `drpc` and `drpc-freemium` from `neon-evm`, `scroll-sepolia-testnet`, and `kava-testnet` due to unresolved issues (which I reported via their Discord support channel).
- Added `quicknode` for `linea` as they have recently started supporting it.
- Added `ankr` to `metis` and `moonbeam`.
- Added well-performing public providers to chains without a paid provider option.