### PR TITLE
fix: update sonic-testnet RPC and browser URLs

### DIFF
--- a/.changeset/fuzzy-foxes-serve.md
+++ b/.changeset/fuzzy-foxes-serve.md
@@ -1,0 +1,5 @@
+---
+'@api3/chains': patch
+---
+
+Fix sonic-testnet rpcUrl and browserUrl

--- a/chains/sonic-testnet.json
+++ b/chains/sonic-testnet.json
@@ -2,14 +2,14 @@
   "alias": "sonic-testnet",
   "decimals": 18,
   "explorer": {
-    "browserUrl": "https://public-sonic.fantom.network/"
+    "browserUrl": "https://testnet.soniclabs.com/"
   },
   "id": "64165",
   "name": "Sonic testnet",
   "providers": [
     {
       "alias": "default",
-      "rpcUrl": "https://rpc.sonic.fantom.network"
+      "rpcUrl": "https://rpc.testnet.soniclabs.com"
     }
   ],
   "symbol": "S",

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -1533,10 +1533,10 @@ export const CHAINS: Chain[] = [
   {
     alias: 'sonic-testnet',
     decimals: 18,
-    explorer: { browserUrl: 'https://public-sonic.fantom.network/' },
+    explorer: { browserUrl: 'https://testnet.soniclabs.com/' },
     id: '64165',
     name: 'Sonic testnet',
-    providers: [{ alias: 'default', rpcUrl: 'https://rpc.sonic.fantom.network' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.testnet.soniclabs.com' }],
     symbol: 'S',
     testnet: true,
   },


### PR DESCRIPTION
Closes #436 based on https://docs.soniclabs.com/sonic/testnet/getting-started