### PR TITLE
Remove broken RPC providers

### DIFF
--- a/.changeset/spotty-foxes-buy.md
+++ b/.changeset/spotty-foxes-buy.md
@@ -1,0 +1,5 @@
+---
+'@api3/chains': patch
+---
+
+Remove Gelato provider from Astar zkEVM and Astar zkEVM testnet

--- a/chains/astar-sepolia-testnet.json
+++ b/chains/astar-sepolia-testnet.json
@@ -16,10 +16,6 @@
     {
       "alias": "default",
       "rpcUrl": "https://rpc.startale.com/zkyoto"
-    },
-    {
-      "alias": "public",
-      "rpcUrl": "https://rpc.zkyoto.gelato.digital"
     }
   ],
   "symbol": "ETH",

--- a/chains/astar.json
+++ b/chains/astar.json
@@ -20,10 +20,6 @@
     {
       "alias": "dwellir",
       "homepageUrl": "https://dwellir.com/"
-    },
-    {
-      "alias": "gelato",
-      "rpcUrl": "https://rpc.astar-zkevm.gelato.digital"
     }
   ],
   "symbol": "ETH",

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -81,10 +81,7 @@ export const CHAINS: Chain[] = [
     },
     id: '6038361',
     name: 'Astar zkEVM testnet',
-    providers: [
-      { alias: 'default', rpcUrl: 'https://rpc.startale.com/zkyoto' },
-      { alias: 'public', rpcUrl: 'https://rpc.zkyoto.gelato.digital' },
-    ],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.startale.com/zkyoto' }],
     symbol: 'ETH',
     testnet: true,
   },
@@ -100,7 +97,6 @@ export const CHAINS: Chain[] = [
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc.startale.com/astar-zkevm' },
       { alias: 'dwellir', homepageUrl: 'https://dwellir.com/' },
-      { alias: 'gelato', rpcUrl: 'https://rpc.astar-zkevm.gelato.digital' },
     ],
     symbol: 'ETH',
     testnet: false,


### PR DESCRIPTION
Closes https://github.com/api3dao/chains/issues/445

It is listed on [docs](https://docs.gelato.network/web3-services/web3-functions/supported-networks) but you cannot create a task using Gelato interface for Astar zkEVM chains