### PR TITLE
Fix outdated chain properties

### DIFF
--- a/.changeset/forty-vans-speak.md
+++ b/.changeset/forty-vans-speak.md
@@ -1,0 +1,15 @@
+---
+'@api3/chains': patch
+---
+
+Fixes following issues:
+* taiko-holesky-testnet
+  - Replace block explorer with a new one
+* gnosis
+  - Change hardhatEtherscanAlias
+* kava
+  - Update api url
+* kava-testnet
+  - Update api url
+* fraxtal-holesky-testnet
+  - Set api key required to true

--- a/.changeset/forty-vans-speak.md
+++ b/.changeset/forty-vans-speak.md
@@ -3,6 +3,8 @@
 ---
 
 Fixes following issues:
+* conflux-testnet
+  - Remove inconsistent rpc url
 * ethereum-sepolia-testnet
   - Remove inconsistent rpc url
 * fraxtal-holesky-testnet

--- a/.changeset/forty-vans-speak.md
+++ b/.changeset/forty-vans-speak.md
@@ -3,13 +3,21 @@
 ---
 
 Fixes following issues:
-* taiko-holesky-testnet
-  - Replace block explorer with a new one
+* ethereum-sepolia-testnet
+  - Remove inconsistent rpc url
+* fraxtal-holesky-testnet
+  - Set api key required to true
 * gnosis
   - Change hardhatEtherscanAlias
 * kava
   - Update api url
 * kava-testnet
   - Update api url
-* fraxtal-holesky-testnet
-  - Set api key required to true
+* taiko
+  - Swap default rpc url with public
+* taiko-holesky-testnet
+  - Replace block explorer with a new one
+* x-layer
+  - Update api url
+* x-layer-sepolia-testnet
+  - Update api url

--- a/chains/conflux-testnet.json
+++ b/chains/conflux-testnet.json
@@ -20,10 +20,6 @@
     {
       "alias": "public",
       "rpcUrl": "https://evmtest.confluxrpc.com/"
-    },
-    {
-      "alias": "backup",
-      "rpcUrl": "https://evmtestnet.confluxrpc.org/"
     }
   ],
   "symbol": "CFX",

--- a/chains/ethereum-sepolia-testnet.json
+++ b/chains/ethereum-sepolia-testnet.json
@@ -16,10 +16,6 @@
   "providers": [
     {
       "alias": "default",
-      "rpcUrl": "https://rpc2.sepolia.org"
-    },
-    {
-      "alias": "publicnode",
       "rpcUrl": "https://ethereum-sepolia-rpc.publicnode.com"
     }
   ],

--- a/chains/fraxtal-holesky-testnet.json
+++ b/chains/fraxtal-holesky-testnet.json
@@ -4,7 +4,7 @@
   "explorer": {
     "api": {
       "key": {
-        "required": false
+        "required": true
       },
       "url": "https://api-holesky.fraxscan.com/api/"
     },

--- a/chains/gnosis.json
+++ b/chains/gnosis.json
@@ -4,7 +4,7 @@
   "explorer": {
     "api": {
       "key": {
-        "hardhatEtherscanAlias": "gnosis",
+        "hardhatEtherscanAlias": "xdai",
         "required": true
       },
       "url": "https://api.gnosisscan.io/api"

--- a/chains/kava-testnet.json
+++ b/chains/kava-testnet.json
@@ -6,7 +6,7 @@
       "key": {
         "required": false
       },
-      "url": "https://testnet.kavascan.com/api"
+      "url": "https://api.verify.mintscan.io/evm/api/0x8ad"
     },
     "browserUrl": "https://testnet.kavascan.com/"
   },

--- a/chains/kava.json
+++ b/chains/kava.json
@@ -6,7 +6,7 @@
       "key": {
         "required": false
       },
-      "url": "https://kavascan.com/api"
+      "url": "https://api.verify.mintscan.io/evm/api/0x8ae"
     },
     "browserUrl": "https://kavascan.com/"
   },

--- a/chains/taiko-holesky-testnet.json
+++ b/chains/taiko-holesky-testnet.json
@@ -4,11 +4,11 @@
   "explorer": {
     "api": {
       "key": {
-        "required": false
+        "required": true
       },
-      "url": "https://blockscoutapi.hekla.taiko.xyz/api"
+      "url": "https://api-hekla.taikoscan.io/api"
     },
-    "browserUrl": "https://blockscoutapi.hekla.taiko.xyz/"
+    "browserUrl": "https://hekla.taikoscan.io/"
   },
   "id": "167009",
   "name": "Taiko testnet",

--- a/chains/taiko.json
+++ b/chains/taiko.json
@@ -15,11 +15,11 @@
   "providers": [
     {
       "alias": "default",
-      "rpcUrl": "https://rpc.taiko.tools"
+      "rpcUrl": "https://rpc.mainnet.taiko.xyz"
     },
     {
       "alias": "public",
-      "rpcUrl": "https://rpc.mainnet.taiko.xyz"
+      "rpcUrl": "https://rpc.taiko.tools"
     },
     {
       "alias": "publicnode",

--- a/chains/x-layer-sepolia-testnet.json
+++ b/chains/x-layer-sepolia-testnet.json
@@ -2,6 +2,12 @@
   "alias": "x-layer-sepolia-testnet",
   "decimals": 18,
   "explorer": {
+    "api": {
+      "key": {
+        "required": false
+      },
+      "url": "https://www.oklink.com/api/v5/explorer/contract/verify-source-code-plugin/XLAYER_TESTNET"
+    },
     "browserUrl": "https://www.okx.com/explorer/xlayer-test/"
   },
   "id": "195",

--- a/chains/x-layer.json
+++ b/chains/x-layer.json
@@ -2,6 +2,12 @@
   "alias": "x-layer",
   "decimals": 18,
   "explorer": {
+    "api": {
+      "key": {
+        "required": false
+      },
+      "url": "https://www.oklink.com/api/v5/explorer/contract/verify-source-code-plugin/XLAYER"
+    },
     "browserUrl": "https://www.okx.com/explorer/xlayer/"
   },
   "id": "196",

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -644,7 +644,7 @@ export const CHAINS: Chain[] = [
     alias: 'fraxtal-holesky-testnet',
     decimals: 18,
     explorer: {
-      api: { key: { required: false }, url: 'https://api-holesky.fraxscan.com/api/' },
+      api: { key: { required: true }, url: 'https://api-holesky.fraxscan.com/api/' },
       browserUrl: 'https://holesky.fraxscan.com/',
     },
     id: '2522',
@@ -694,7 +694,7 @@ export const CHAINS: Chain[] = [
     alias: 'gnosis',
     decimals: 18,
     explorer: {
-      api: { key: { hardhatEtherscanAlias: 'gnosis', required: true }, url: 'https://api.gnosisscan.io/api' },
+      api: { key: { hardhatEtherscanAlias: 'xdai', required: true }, url: 'https://api.gnosisscan.io/api' },
       browserUrl: 'https://gnosisscan.io/',
     },
     id: '100',
@@ -774,7 +774,7 @@ export const CHAINS: Chain[] = [
     alias: 'kava-testnet',
     decimals: 18,
     explorer: {
-      api: { key: { required: false }, url: 'https://testnet.kavascan.com/api' },
+      api: { key: { required: false }, url: 'https://api.verify.mintscan.io/evm/api/0x8ad' },
       browserUrl: 'https://testnet.kavascan.com/',
     },
     id: '2221',
@@ -787,7 +787,7 @@ export const CHAINS: Chain[] = [
     alias: 'kava',
     decimals: 18,
     explorer: {
-      api: { key: { required: false }, url: 'https://kavascan.com/api' },
+      api: { key: { required: false }, url: 'https://api.verify.mintscan.io/evm/api/0x8ae' },
       browserUrl: 'https://kavascan.com/',
     },
     id: '2222',
@@ -1618,8 +1618,8 @@ export const CHAINS: Chain[] = [
     alias: 'taiko-holesky-testnet',
     decimals: 18,
     explorer: {
-      api: { key: { required: false }, url: 'https://blockscoutapi.hekla.taiko.xyz/api' },
-      browserUrl: 'https://blockscoutapi.hekla.taiko.xyz/',
+      api: { key: { required: true }, url: 'https://api-hekla.taikoscan.io/api' },
+      browserUrl: 'https://hekla.taikoscan.io/',
     },
     id: '167009',
     name: 'Taiko testnet',

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -489,7 +489,6 @@ export const CHAINS: Chain[] = [
     providers: [
       { alias: 'default', rpcUrl: 'https://evmtestnet.confluxrpc.com/' },
       { alias: 'public', rpcUrl: 'https://evmtest.confluxrpc.com/' },
-      { alias: 'backup', rpcUrl: 'https://evmtestnet.confluxrpc.org/' },
     ],
     symbol: 'CFX',
     testnet: true,

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -579,10 +579,7 @@ export const CHAINS: Chain[] = [
     },
     id: '11155111',
     name: 'Ethereum Sepolia testnet',
-    providers: [
-      { alias: 'default', rpcUrl: 'https://rpc2.sepolia.org' },
-      { alias: 'publicnode', rpcUrl: 'https://ethereum-sepolia-rpc.publicnode.com' },
-    ],
+    providers: [{ alias: 'default', rpcUrl: 'https://ethereum-sepolia-rpc.publicnode.com' }],
     symbol: 'ETH',
     testnet: true,
   },
@@ -1640,8 +1637,8 @@ export const CHAINS: Chain[] = [
     id: '167000',
     name: 'Taiko',
     providers: [
-      { alias: 'default', rpcUrl: 'https://rpc.taiko.tools' },
-      { alias: 'public', rpcUrl: 'https://rpc.mainnet.taiko.xyz' },
+      { alias: 'default', rpcUrl: 'https://rpc.mainnet.taiko.xyz' },
+      { alias: 'public', rpcUrl: 'https://rpc.taiko.tools' },
       { alias: 'publicnode', rpcUrl: 'https://taiko-rpc.publicnode.com' },
       { alias: 'ankr', homepageUrl: 'https://ankr.com' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -1694,7 +1694,13 @@ export const CHAINS: Chain[] = [
   {
     alias: 'x-layer-sepolia-testnet',
     decimals: 18,
-    explorer: { browserUrl: 'https://www.okx.com/explorer/xlayer-test/' },
+    explorer: {
+      api: {
+        key: { required: false },
+        url: 'https://www.oklink.com/api/v5/explorer/contract/verify-source-code-plugin/XLAYER_TESTNET',
+      },
+      browserUrl: 'https://www.okx.com/explorer/xlayer-test/',
+    },
     id: '195',
     name: 'X Layer testnet',
     providers: [
@@ -1707,7 +1713,13 @@ export const CHAINS: Chain[] = [
   {
     alias: 'x-layer',
     decimals: 18,
-    explorer: { browserUrl: 'https://www.okx.com/explorer/xlayer/' },
+    explorer: {
+      api: {
+        key: { required: false },
+        url: 'https://www.oklink.com/api/v5/explorer/contract/verify-source-code-plugin/XLAYER',
+      },
+      browserUrl: 'https://www.okx.com/explorer/xlayer/',
+    },
     id: '196',
     name: 'X Layer',
     providers: [


### PR DESCRIPTION
Closes #488 

This PR fixes following issues:
* ethereum-sepolia-testnet
  - Remove [inconsistent rpc](https://status.sepolia.org) url
* fraxtal-holesky-testnet
  - Set api key required to true
* gnosis
  - Change hardhatEtherscanAlias
* kava
  - [Update api url](https://docs.kava.io/docs/ethereum/contract_verification/#via-hardhat-verification-plugin)
* kava-testnet
  - [Update api url](https://docs.kava.io/docs/ethereum/contract_verification/#via-hardhat-verification-plugin)
* taiko
  - Swap default rpc url with public
* taiko-holesky-testnet
  - Replace block explorer with a new one
* x-layer
  - Update [api url](https://www.okx.com/xlayer/docs/developer/verify-a-smart-contract/verify-with-hardhat)
* x-layer-sepolia-testnet
  - Update [api url](https://www.okx.com/xlayer/docs/developer/verify-a-smart-contract/verify-with-hardhat)