### PR TITLE
Update providers

### DIFF
--- a/.changeset/popular-rats-rule.md
+++ b/.changeset/popular-rats-rule.md
@@ -1,0 +1,5 @@
+---
+'@api3/chains': patch
+---
+
+Update providers

--- a/chains/fraxtal.json
+++ b/chains/fraxtal.json
@@ -21,10 +21,7 @@
       "alias": "drpc",
       "homepageUrl": "https://drpc.org"
     },
-    {
-      "alias": "grove",
-      "homepageUrl": "https://grove.city/"
-    },
+
     {
       "alias": "tenderly",
       "homepageUrl": "https://tenderly.co/"

--- a/chains/mantle-sepolia-testnet.json
+++ b/chains/mantle-sepolia-testnet.json
@@ -16,10 +16,6 @@
     {
       "alias": "default",
       "rpcUrl": "https://rpc.sepolia.mantle.xyz"
-    },
-    {
-      "alias": "drpc-freemium",
-      "rpcUrl": "https://lb.drpc.org/ogrpc?network=mantle-sepolia&dkey=AiPHJac9aUX2s7ELd131NuwSeHqkUW8R7oQiFnomaLKw"
     }
   ],
   "symbol": "MNT",

--- a/chains/metis.json
+++ b/chains/metis.json
@@ -28,10 +28,6 @@
     {
       "alias": "drpc",
       "homepageUrl": "https://drpc.org"
-    },
-    {
-      "alias": "grove",
-      "homepageUrl": "https://grove.city/"
     }
   ],
   "symbol": "METIS",

--- a/chains/moonbeam-testnet.json
+++ b/chains/moonbeam-testnet.json
@@ -17,10 +17,6 @@
     {
       "alias": "default",
       "rpcUrl": "https://rpc.api.moonbase.moonbeam.network"
-    },
-    {
-      "alias": "drpc-freemium",
-      "rpcUrl": "https://lb.drpc.org/ogrpc?network=moonbase-alpha&dkey=AiPHJac9aUX2s7ELd131NuwSeHqkUW8R7oQiFnomaLKw"
     }
   ],
   "symbol": "GLMR",

--- a/chains/scroll.json
+++ b/chains/scroll.json
@@ -18,12 +18,12 @@
       "rpcUrl": "https://rpc.scroll.io"
     },
     {
-      "alias": "drpc",
-      "homepageUrl": "https://drpc.org"
+      "alias": "publicnode",
+      "rpcUrl": "https://scroll-rpc.publicnode.com"
     },
     {
-      "alias": "blockpi",
-      "homepageUrl": "https://blockpi.io"
+      "alias": "drpc",
+      "homepageUrl": "https://drpc.org"
     },
     {
       "alias": "blastapi",

--- a/chains/sei.json
+++ b/chains/sei.json
@@ -12,6 +12,10 @@
       "rpcUrl": "https://evm-rpc.sei-apis.com/"
     },
     {
+      "alias": "publicnode",
+      "rpcUrl": "https://sei-evm-rpc.publicnode.com"
+    },
+    {
       "alias": "drpc",
       "homepageUrl": "https://drpc.org"
     },

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -674,7 +674,6 @@ export const CHAINS: Chain[] = [
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc.frax.com' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
-      { alias: 'grove', homepageUrl: 'https://grove.city/' },
       { alias: 'tenderly', homepageUrl: 'https://tenderly.co/' },
     ],
     symbol: 'ETH',
@@ -1144,7 +1143,6 @@ export const CHAINS: Chain[] = [
       { alias: 'ankr', homepageUrl: 'https://ankr.com' },
       { alias: 'blastapi', homepageUrl: 'https://blastapi.io' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
-      { alias: 'grove', homepageUrl: 'https://grove.city/' },
     ],
     symbol: 'METIS',
     testnet: false,

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -995,13 +995,7 @@ export const CHAINS: Chain[] = [
     },
     id: '5003',
     name: 'Mantle testnet',
-    providers: [
-      { alias: 'default', rpcUrl: 'https://rpc.sepolia.mantle.xyz' },
-      {
-        alias: 'drpc-freemium',
-        rpcUrl: 'https://lb.drpc.org/ogrpc?network=mantle-sepolia&dkey=AiPHJac9aUX2s7ELd131NuwSeHqkUW8R7oQiFnomaLKw',
-      },
-    ],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.sepolia.mantle.xyz' }],
     symbol: 'MNT',
     testnet: true,
   },
@@ -1217,13 +1211,7 @@ export const CHAINS: Chain[] = [
     },
     id: '1287',
     name: 'Moonbeam testnet',
-    providers: [
-      { alias: 'default', rpcUrl: 'https://rpc.api.moonbase.moonbeam.network' },
-      {
-        alias: 'drpc-freemium',
-        rpcUrl: 'https://lb.drpc.org/ogrpc?network=moonbase-alpha&dkey=AiPHJac9aUX2s7ELd131NuwSeHqkUW8R7oQiFnomaLKw',
-      },
-    ],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.api.moonbase.moonbeam.network' }],
     symbol: 'GLMR',
     testnet: true,
   },

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -1552,6 +1552,7 @@ export const CHAINS: Chain[] = [
     name: 'Sei',
     providers: [
       { alias: 'default', rpcUrl: 'https://evm-rpc.sei-apis.com/' },
+      { alias: 'publicnode', rpcUrl: 'https://sei-evm-rpc.publicnode.com' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
       { alias: 'quicknode', homepageUrl: 'https://quicknode.com' },
     ],

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -1526,8 +1526,8 @@ export const CHAINS: Chain[] = [
     name: 'Scroll',
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc.scroll.io' },
+      { alias: 'publicnode', rpcUrl: 'https://scroll-rpc.publicnode.com' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
-      { alias: 'blockpi', homepageUrl: 'https://blockpi.io' },
       { alias: 'blastapi', homepageUrl: 'https://blastapi.io' },
       { alias: 'quicknode', homepageUrl: 'https://quicknode.com' },
     ],


### PR DESCRIPTION
Basically this PR:
- Removes providers `grove` and `drpc-freemium` because of drops in availability
- Adds provider `publicnode` for `sei`
- Switchs `blockpi` to better alternative `publicnode` for `scroll`