### PR TITLE
Csur 2024-12-04

### DIFF
--- a/.changeset/friendly-pots-repair.md
+++ b/.changeset/friendly-pots-repair.md
@@ -1,0 +1,5 @@
+---
+'@api3/chains': major
+---
+
+Update URLs and chain id for `sonic-testnet`

--- a/chains/sonic-testnet.json
+++ b/chains/sonic-testnet.json
@@ -2,14 +2,14 @@
   "alias": "sonic-testnet",
   "decimals": 18,
   "explorer": {
-    "browserUrl": "https://testnet.soniclabs.com/"
+    "browserUrl": "https://blaze.soniclabs.com/"
   },
-  "id": "64165",
+  "id": "57054",
   "name": "Sonic testnet",
   "providers": [
     {
       "alias": "default",
-      "rpcUrl": "https://rpc.testnet.soniclabs.com"
+      "rpcUrl": "https://rpc.blaze.soniclabs.com"
     }
   ],
   "symbol": "S",

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -1588,10 +1588,10 @@ export const CHAINS: Chain[] = [
   {
     alias: 'sonic-testnet',
     decimals: 18,
-    explorer: { browserUrl: 'https://testnet.soniclabs.com/' },
-    id: '64165',
+    explorer: { browserUrl: 'https://blaze.soniclabs.com/' },
+    id: '57054',
     name: 'Sonic testnet',
-    providers: [{ alias: 'default', rpcUrl: 'https://rpc.testnet.soniclabs.com' }],
+    providers: [{ alias: 'default', rpcUrl: 'https://rpc.blaze.soniclabs.com' }],
     symbol: 'S',
     testnet: true,
   },


### PR DESCRIPTION
Closes https://github.com/api3dao/chains/issues/509

This is a major release and contains following changes:
* New chain id and url update for `sonic-testnet`

This chain does not support contract verification, so there is no block explorer api available 