### PR TITLE
Fix fantom-testnet default rpc

### DIFF
--- a/.changeset/grumpy-experts-collect.md
+++ b/.changeset/grumpy-experts-collect.md
@@ -1,0 +1,5 @@
+---
+'@api3/chains': patch
+---
+
+Fix fantom-testnet default rpc

--- a/chains/fantom-testnet.json
+++ b/chains/fantom-testnet.json
@@ -16,10 +16,6 @@
   "providers": [
     {
       "alias": "default",
-      "rpcUrl": "https://rpc.testnet.fantom.network"
-    },
-    {
-      "alias": "publicnode",
       "rpcUrl": "https://fantom-testnet-rpc.publicnode.com"
     }
   ],

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -623,10 +623,7 @@ export const CHAINS: Chain[] = [
     },
     id: '4002',
     name: 'Fantom testnet',
-    providers: [
-      { alias: 'default', rpcUrl: 'https://rpc.testnet.fantom.network' },
-      { alias: 'publicnode', rpcUrl: 'https://fantom-testnet-rpc.publicnode.com' },
-    ],
+    providers: [{ alias: 'default', rpcUrl: 'https://fantom-testnet-rpc.publicnode.com' }],
     symbol: 'FTM',
     testnet: true,
   },


### PR DESCRIPTION
* Fantom testnet rpc url is not working properly. This pr updates the default rpc with working now.