### PR TITLE
Replace quicknode with publicnode for linea

### DIFF
--- a/.changeset/kind-lions-cross.md
+++ b/.changeset/kind-lions-cross.md
@@ -1,0 +1,5 @@
+---
+'@api3/chains': patch
+---
+
+Replace quicknode with publicnode for linea

--- a/chains/linea.json
+++ b/chains/linea.json
@@ -18,16 +18,16 @@
       "rpcUrl": "https://rpc.linea.build"
     },
     {
+      "alias": "publicnode",
+      "rpcUrl": "https://linea-rpc.publicnode.com"
+    },
+    {
       "alias": "blastapi",
       "homepageUrl": "https://blastapi.io"
     },
     {
       "alias": "drpc",
       "homepageUrl": "https://drpc.org/"
-    },
-    {
-      "alias": "quicknode",
-      "homepageUrl": "https://quicknode.com"
     },
     {
       "alias": "reblok",

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -904,9 +904,9 @@ export const CHAINS: Chain[] = [
     name: 'Linea',
     providers: [
       { alias: 'default', rpcUrl: 'https://rpc.linea.build' },
+      { alias: 'publicnode', rpcUrl: 'https://linea-rpc.publicnode.com' },
       { alias: 'blastapi', homepageUrl: 'https://blastapi.io' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org/' },
-      { alias: 'quicknode', homepageUrl: 'https://quicknode.com' },
       { alias: 'reblok', homepageUrl: 'https://reblok.io' },
     ],
     symbol: 'ETH',


### PR DESCRIPTION
QuickNode requires an additional purchase for the Linea endpoint, and it cannot be used with the multi-chain endpoint. To maintain multi-chain functionality, I suggest removing it.