### PR TITLE
Remove ankr from polygon

### DIFF
--- a/.changeset/honest-plants-tan.md
+++ b/.changeset/honest-plants-tan.md
@@ -1,0 +1,5 @@
+---
+'@api3/chains': patch
+---
+
+Remove ankr provider from Polygon

--- a/chains/polygon.json
+++ b/chains/polygon.json
@@ -19,10 +19,6 @@
       "rpcUrl": "https://polygon-bor-rpc.publicnode.com"
     },
     {
-      "alias": "ankr",
-      "homepageUrl": "https://ankr.com"
-    },
-    {
       "alias": "blastapi",
       "homepageUrl": "https://blastapi.io"
     },

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -1461,7 +1461,6 @@ export const CHAINS: Chain[] = [
     name: 'Polygon',
     providers: [
       { alias: 'default', rpcUrl: 'https://polygon-bor-rpc.publicnode.com' },
-      { alias: 'ankr', homepageUrl: 'https://ankr.com' },
       { alias: 'blastapi', homepageUrl: 'https://blastapi.io' },
       { alias: 'drpc', homepageUrl: 'https://drpc.org' },
       { alias: 'quicknode', homepageUrl: 'https://quicknode.com' },


### PR DESCRIPTION
Context: ankr returnes cached data on `eth_call` endpoint

Related to #527 
See [thread](https://api3workspace.slack.com/archives/C05RMQJ3X2L/p1734049355849149)

Also [example](https://api3workspace.slack.com/archives/C05RMQJ3X2L/p1734034235172479), [example](https://api3workspace.slack.com/archives/C05RMQJ3X2L/p1733926236032789), [example](https://api3workspace.slack.com/archives/C05RMQJ3X2L/p1733849032329649), [example](https://api3workspace.slack.com/archives/C05RMQJ3X2L/p1733849032329649)