### PR TITLE
Change default rpc for berachain-testnet

### DIFF
--- a/.changeset/empty-trainers-do.md
+++ b/.changeset/empty-trainers-do.md
@@ -1,0 +1,5 @@
+---
+'@api3/chains': patch
+---
+
+Swap Berachain testnet RPC URLs

--- a/chains/berachain-testnet.json
+++ b/chains/berachain-testnet.json
@@ -15,11 +15,11 @@
   "providers": [
     {
       "alias": "default",
-      "rpcUrl": "https://bartio.rpc.berachain.com/"
+      "rpcUrl": "https://berachain-testnet-evm-rpc.publicnode.com"
     },
     {
       "alias": "publicnode",
-      "rpcUrl": "https://berachain-testnet-evm-rpc.publicnode.com"
+      "rpcUrl": "https://bartio.rpc.berachain.com"
     }
   ],
   "symbol": "BERA",

--- a/chains/berachain-testnet.json
+++ b/chains/berachain-testnet.json
@@ -18,7 +18,7 @@
       "rpcUrl": "https://berachain-testnet-evm-rpc.publicnode.com"
     },
     {
-      "alias": "publicnode",
+      "alias": "official",
       "rpcUrl": "https://bartio.rpc.berachain.com"
     }
   ],

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -254,7 +254,7 @@ export const CHAINS: Chain[] = [
     name: 'Berachain testnet',
     providers: [
       { alias: 'default', rpcUrl: 'https://berachain-testnet-evm-rpc.publicnode.com' },
-      { alias: 'publicnode', rpcUrl: 'https://bartio.rpc.berachain.com' },
+      { alias: 'official', rpcUrl: 'https://bartio.rpc.berachain.com' },
     ],
     symbol: 'BERA',
     testnet: true,

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -253,8 +253,8 @@ export const CHAINS: Chain[] = [
     id: '80084',
     name: 'Berachain testnet',
     providers: [
-      { alias: 'default', rpcUrl: 'https://bartio.rpc.berachain.com/' },
-      { alias: 'publicnode', rpcUrl: 'https://berachain-testnet-evm-rpc.publicnode.com' },
+      { alias: 'default', rpcUrl: 'https://berachain-testnet-evm-rpc.publicnode.com' },
+      { alias: 'publicnode', rpcUrl: 'https://bartio.rpc.berachain.com' },
     ],
     symbol: 'BERA',
     testnet: true,


### PR DESCRIPTION
Related to #534 

* Publicnode rpc is working more reliable than current default rpc
* berachain-testnet `default` rpc is swapped with `publicnode` rpc. 
* Default rpc is not removed entirely as it shows signs of recovery and will be remain monitored 