### PR TITLE
Update outdated kroma block explorer

### DIFF
--- a/.changeset/little-rats-tap.md
+++ b/.changeset/little-rats-tap.md
@@ -1,0 +1,5 @@
+---
+'@api3/chains': patch
+---
+
+Update block explorer for kroma

--- a/chains/kroma.json
+++ b/chains/kroma.json
@@ -4,11 +4,11 @@
   "explorer": {
     "api": {
       "key": {
-        "required": true
+        "required": false
       },
-      "url": "https://api.kromascan.com/api"
+      "url": "https://api.routescan.io/v2/network/mainnet/evm/255/etherscan"
     },
-    "browserUrl": "https://kromascan.com/"
+    "browserUrl": "https://kroscan.io/"
   },
   "id": "255",
   "name": "Kroma",

--- a/src/generated/chains.ts
+++ b/src/generated/chains.ts
@@ -101,8 +101,8 @@ export const CHAINS: Chain[] = [
     id: '6038361',
     name: 'Astar zkEVM testnet',
     providers: [{ alias: 'default', rpcUrl: 'https://rpc.startale.com/zkyoto' }],
-    symbol: 'ETH',
     skipProviderCheck: true,
+    symbol: 'ETH',
     testnet: true,
   },
   {
@@ -884,8 +884,8 @@ export const CHAINS: Chain[] = [
     alias: 'kroma',
     decimals: 18,
     explorer: {
-      api: { key: { required: true }, url: 'https://api.kromascan.com/api' },
-      browserUrl: 'https://kromascan.com/',
+      api: { key: { required: false }, url: 'https://api.routescan.io/v2/network/mainnet/evm/255/etherscan' },
+      browserUrl: 'https://kroscan.io/',
     },
     id: '255',
     name: 'Kroma',


### PR DESCRIPTION
Closes #561 

> Kroma has changed its block explorer as shown in [docs](https://docs.kroma.network/users/block-explorer).
> 
> New block explorer: https://kroscan.io/
> [API](https://kroscan.io/documentation/recipes/hardhat-verification): https://api.routescan.io/v2/network/mainnet/evm/255/etherscan 